### PR TITLE
linux-hikey 3.18: Backported dependency fix on libgcc

### DIFF
--- a/recipes-kernel/linux/linux-hikey/0001-arm64-kill-off-the-libgcc-dependency.patch
+++ b/recipes-kernel/linux/linux-hikey/0001-arm64-kill-off-the-libgcc-dependency.patch
@@ -1,0 +1,54 @@
+From d67703a8a69eecc8367bb9f848640b9efd430337 Mon Sep 17 00:00:00 2001
+From: Kevin Hao <haokexin@gmail.com>
+Date: Thu, 15 Jan 2015 12:07:33 +0000
+Subject: [PATCH] arm64: kill off the libgcc dependency
+
+The arm64 kernel builds fine without the libgcc. Actually it should not
+be used at all in the kernel. The following are the reasons indicated
+by Russell King:
+
+  Although libgcc is part of the compiler, libgcc is built with the
+  expectation that it will be running in userland - it expects to link
+  to a libc.  That's why you can't build libgcc without having the glibc
+  headers around.
+
+  [...]
+
+  Meanwhile, having the kernel build the compiler support functions that
+  it needs ensures that (a) we know what compiler support functions are
+  being used, (b) we know the implementation of those support functions
+  are sane for use in the kernel, (c) we can build them with appropriate
+  compiler flags for best performance, and (d) we remove an unnecessary
+  dependency on the build toolchain.
+
+Signed-off-by: Kevin Hao <haokexin@gmail.com>
+Acked-by: Will Deacon <will.deacon@arm.com>
+Signed-off-by: Catalin Marinas <catalin.marinas@arm.com>
+---
+ arch/arm64/Makefile | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
+index 1c43cec..a20c283 100644
+--- a/arch/arm64/Makefile
++++ b/arch/arm64/Makefile
+@@ -15,8 +15,6 @@ CPPFLAGS_vmlinux.lds = -DTEXT_OFFSET=$(TEXT_OFFSET)
+ OBJCOPYFLAGS	:=-O binary -R .note -R .note.gnu.build-id -R .comment -S
+ GZFLAGS		:=-9
+ 
+-LIBGCC 		:= $(shell $(CC) $(KBUILD_CFLAGS) -print-libgcc-file-name)
+-
+ KBUILD_DEFCONFIG := defconfig
+ 
+ KBUILD_CFLAGS	+= -mgeneral-regs-only
+@@ -50,7 +48,6 @@ core-$(CONFIG_KVM) += arch/arm64/kvm/
+ core-$(CONFIG_XEN) += arch/arm64/xen/
+ core-$(CONFIG_CRYPTO) += arch/arm64/crypto/
+ libs-y		:= arch/arm64/lib/ $(libs-y)
+-libs-y		+= $(LIBGCC)
+ libs-$(CONFIG_EFI_STUB) += drivers/firmware/efi/libstub/
+ 
+ # Default target when executing plain make
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-hikey_3.18.bb
+++ b/recipes-kernel/linux/linux-hikey_3.18.bb
@@ -11,6 +11,7 @@ SRCREV_kernel="a6e868e500218441c99f757f8f8cebdbfcec0f67"
 SRC_URI = "git://github.com/96boards/linux.git;branch=hikey;name=kernel \
            file://0001-CRDA-add-full-db-into-kernel.patch \
            file://defconfig \
+           file://0001-arm64-kill-off-the-libgcc-dependency.patch\
           "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
OE builds fails with a linking error to libgcc.a.
This patch is backported from Torvald's 3.19 tree.

Signed-off-by: Zoltan Kuscsik zoltan.kuscsik@linaro.org
