### PR TITLE
xserver-xf86-config: Add xorg.conf for hikey

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/hikey/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/hikey/xorg.conf
@@ -1,0 +1,19 @@
+Section "InputClass"
+	Identifier          "touchpad"
+	MatchIsTouchpad     "on"
+	Option              "FingerHigh"            "5"
+	Option              "FingerLow"             "5"
+	EndSection
+
+Section "Device"
+	Identifier      "Mali FBDEV"
+	Driver          "fbdev"
+	Option          "fbdev"                 "/dev/fb0"
+EndSection
+
+Section "Screen"
+	Identifier      "DefaultScreen"
+	Device          "Mali FBDEV"
+	DefaultDepth    24
+EndSection
+

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend = "${THISDIR}/${PN}:"


### PR DESCRIPTION
helps in building xfce-nm-image

Signed-off-by: Khem Raj raj.khem@gmail.com
