### PR TITLE
xserver-xf86-config: fix typo

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS_prepend = "${THISDIR}/${PN}:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
When using FILESEXTRAPATH, we need to use immediate variable expansion,
otherwise we don't use the proper value for THISDIR.

Signed-off-by: Nicolas Dechesne nicolas.dechesne@linaro.org
