### PR TITLE
96boards-tools: add initial recipe

### DIFF
--- a/recipes-bsp/96boards-tools/96boards-tools_0.4.bb
+++ b/recipes-bsp/96boards-tools/96boards-tools_0.4.bb
@@ -1,0 +1,27 @@
+SUMMARY = "Useful bits an pieces to make 96Boards more standard across the board"
+HOMEPAGE = "https://github.com/96boards/96boards-tools"
+SECTION = "devel"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+SRCREV = "4ea96f492291071ce1d26a854f28e518d15611a9"
+SRC_URI = "git://github.com/96boards/96boards-tools;branch=master;protocol=https"
+
+S = "${WORKDIR}/git"
+
+inherit systemd allarch
+
+do_install () {
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0755 ${S}/*.rules ${D}${sysconfdir}/udev/rules.d/
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/resize-helper.service ${D}${systemd_unitdir}/system
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/resize-helper ${D}${sbindir}
+}
+
+SYSTEMD_SERVICE_${PN} = "resize-helper.service"
+RDEPENDS_${PN} += "e2fsprogs-resize2fs parted util-linux udev"


### PR DESCRIPTION
- udev rule for standard UART device name
- boot script to resize rootfs to match partition size on first boot

Signed-off-by: Nicolas Dechesne nicolas.dechesne@linaro.org
