### PR TITLE
96boards-tools: Add gptfdisk to rdeps

### DIFF
--- a/recipes-bsp/96boards-tools/96boards-tools_0.4.bb
+++ b/recipes-bsp/96boards-tools/96boards-tools_0.4.bb
@@ -24,4 +24,4 @@ do_install () {
 }
 
 SYSTEMD_SERVICE_${PN} = "resize-helper.service"
-RDEPENDS_${PN} += "e2fsprogs-resize2fs parted util-linux udev"
+RDEPENDS_${PN} += "e2fsprogs-resize2fs gptfdisk parted util-linux udev"


### PR DESCRIPTION
sgdisk is used by resize-helper script

Signed-off-by: Khem Raj raj.khem@gmail.com
