### PR TITLE
linux-96boards: Add native includedir to HOST_EXTRACFLAGS

### DIFF
--- a/recipes-kernel/linux/linux-96boards_4.4.bb
+++ b/recipes-kernel/linux/linux-96boards_4.4.bb
@@ -13,7 +13,7 @@ COMPATIBLE_MACHINE = "96boards-64|hikey"
 KERNEL_IMAGETYPE ?= "Image"
 # make[3]: *** [scripts/extract-cert] Error 1
 DEPENDS += "openssl-native"
-HOSTCFLAGS += "-I${STAGING_INCDIR_NATIVE}"
+HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
 
 do_configure() {
     cp ${S}/arch/arm64/configs/distro.config ${B}/.config


### PR DESCRIPTION
HOSTCFLAGS are overwritten inside kernel makery so it loses
it.

Fix Suggested/Tested by Nicolas Dechesne

Fixes
https://bugs.linaro.org/show_bug.cgi?id=2181

Signed-off-by: Khem Raj raj.khem@gmail.com
