### PR TITLE
linux-96boards_4.4: updating SRCREV to the 16.06 RC1

### DIFF
--- a/recipes-kernel/linux/linux-96boards_4.4.bb
+++ b/recipes-kernel/linux/linux-96boards_4.4.bb
@@ -2,8 +2,8 @@ require linux.inc
 
 DESCRIPTION = "Generic 96boards kernel"
 
-PV = "4.4.8+git"
-SRCREV_kernel = "512284bf605ae63d7f54777a8fc63c2735aa90e4"
+PV = "4.4.11+git"
+SRCREV_kernel = "7a744713ee54955c6ffb6eda6ba888e8b482ead4"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "git://github.com/96boards/linux.git;protocol=https;branch=96b/releases/2016.06;name=kernel \


### PR DESCRIPTION
To match the same version used by the Debian RPBs.

Signed-off-by: Ricardo Salveti de Araujo ricardo.salveti@linaro.org
