### PR TITLE
grub: fix grubimage values

### DIFF
--- a/recipes-bsp/grub/grub_git.bb
+++ b/recipes-bsp/grub/grub_git.bb
@@ -36,13 +36,13 @@ python __anonymous () {
     target = d.getVar('TARGET_ARCH', True)
     if target == "x86_64":
         grubtarget = 'x86_64'
-        grubimage = "bootx64.efi"
+        grubimage = "grubx64.efi"
     elif re.match('i.86', target):
         grubtarget = 'i386'
-        grubimage = "bootia32.efi"
+        grubimage = "grubia32.efi"
     elif re.match('aarch64', target):
         grubtarget = 'arm64'
-        grubimage = "bootaa64.efi"
+        grubimage = "grubaa64.efi"
     else:
         raise bb.parse.SkipPackage("grub-efi is incompatible with target %s" % target)
     d.setVar("GRUB_TARGET", grubtarget)


### PR DESCRIPTION
boot${arch}.efi is used as a fallback and for removable media.
See also:
https://www.happyassassin.net/2014/01/25/uefi-boot-how-does-that-actually-work-then/
http://www.rodsbooks.com/efi-bootloaders/bootrepair.html

GRUB image on main distributions (Debian, Ubuntu, Fedora, etc..) is named
grub${arch}.efi for an installed system and also to avoid collision.

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
