### PR TITLE
hikey: bootimg: create HiKey boot image

### DIFF
--- a/recipes-kernel/linux/linux-96boards-bootimg.inc
+++ b/recipes-kernel/linux/linux-96boards-bootimg.inc
@@ -1,0 +1,24 @@
+DEPENDS += "dosfstools-native mtools-native"
+
+# Create a 64M boot image. block size is 1024. (64*1024=65536)
+BOOT_IMAGE_SIZE = 65536
+BOOT_IMAGE_BASE_NAME = "boot-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
+BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+
+do_deploy_append_hikey() {
+    # FIXME: build grubaa64.efi instead of pre-built file
+    GRUB_EFI_BUILD_NUMBER=$(wget -q --no-check-certificate -O - https://ci.linaro.org/job/96boards-reference-grub-efi-arm64/lastSuccessfulBuild/buildNumber)
+    GRUB_EFI_URL="https://builds.96boards.org/snapshots/reference-platform/components/grub/${GRUB_EFI_BUILD_NUMBER}"
+    wget --progress=dot ${GRUB_EFI_URL}/grubaa64.efi -O ${DEPLOYDIR}/grubaa64.efi
+
+    # Create boot image
+    mkfs.vfat -F32 -n "boot" -C ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${BOOT_IMAGE_SIZE}
+    mmd -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI
+    mmd -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI/BOOT
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${DEPLOYDIR}/fastboot.efi ::EFI/BOOT/fastboot.efi
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${DEPLOYDIR}/grubaa64.efi ::EFI/BOOT/grubaa64.efi
+    chmod 644 ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img
+    rm -f ${DEPLOYDIR}/*.efi
+
+    (cd ${DEPLOYDIR} && ln -sf ${BOOT_IMAGE_BASE_NAME}.uefi.img boot-${MACHINE}.uefi.img)
+}

--- a/recipes-kernel/linux/linux-96boards_4.4.bb
+++ b/recipes-kernel/linux/linux-96boards_4.4.bb
@@ -1,4 +1,5 @@
 require linux.inc
+require linux-96boards-bootimg.inc
 
 DESCRIPTION = "Generic 96boards kernel"
 


### PR DESCRIPTION
Create HiKey boot image to be flashed on eMMC.

Use pre-built fastboot.efi and grubaa64.efi binaries from Debian RPB
builds until EDK2 and GRUB recipes are able to generate them.

Notes:
- It depends on dosfstools and mtools native.
- Approach is similar to 410c, except we don't depend on the kernel recipe
  build artifacts. We'll need to do it after EDK2/GRUB recipes are built.

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
