### PR TITLE
linux-96boards-bootimg: add missing double quotes

### DIFF
--- a/recipes-kernel/linux/linux-96boards-bootimg.inc
+++ b/recipes-kernel/linux/linux-96boards-bootimg.inc
@@ -1,7 +1,7 @@
 DEPENDS += "dosfstools-native mtools-native"
 
 # Create a 64M boot image. block size is 1024. (64*1024=65536)
-BOOT_IMAGE_SIZE = 65536
+BOOT_IMAGE_SIZE = "65536"
 BOOT_IMAGE_BASE_NAME = "boot-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
 BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 


### PR DESCRIPTION
Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
