### PR TITLE
hikey: depends on edk2-hikey

### DIFF
--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -36,4 +36,4 @@ CMDLINE = "console=ttyAMA0,115200n8 root=/dev/mmcblk1p2 rootwait ro maxcpus=8 ea
 # Fastboot expects an ext4 image
 IMAGE_FSTYPES_append = " ext4.gz"
 
-EXTRA_IMAGEDEPENDS = "edk2 l-loader"
+EXTRA_IMAGEDEPENDS = "edk2-hikey l-loader"


### PR DESCRIPTION
Update extra image dependency to use edk2-hikey machine specific recipe
instead of the base recipe.

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
