### PR TITLE
edk2-hikey: use DEPLOY_DIR_IMAGE instead of DEPLOYDIR

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -16,11 +16,11 @@ do_install() {
 }
 
 do_deploy() {
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${DEPLOYDIR}/bl1.bin
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl2.bin ${DEPLOYDIR}/bl2.bin
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOYDIR}/fip.bin
-    install -D -p -m0644 ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ${DEPLOYDIR}/fastboot.efi
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${DEPLOY_DIR_IMAGE}/bl1.bin
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl2.bin ${DEPLOY_DIR_IMAGE}/bl2.bin
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOY_DIR_IMAGE}/fip.bin
+    install -D -p -m0644 ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ${DEPLOY_DIR_IMAGE}/fastboot.efi
 
     # Ship nvme.img with UEFI binaries for convenience
-    dd if=/dev/zero of=${DEPLOYDIR}/nvme.img bs=128 count=1024
+    dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/nvme.img bs=128 count=1024
 }


### PR DESCRIPTION
same as
https://github.com/96boards/meta-96boards/commit/1f5e68f86282e254229b2d3bf3eb9b1b2fdb0abf

Reported-by: Andrey Konovalov andrey.konovalov@linaro.org
Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
