### PR TITLE
Mali450 userland v2

### DIFF
--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -13,7 +13,7 @@ XSERVER ?= "xserver-xorg \
             xf86-video-fbdev \
             xf86-input-keyboard"
 
-MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth efi optee"
+MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth efi optee mali450"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-96boards"
 

--- a/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
+++ b/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
@@ -1,0 +1,55 @@
+SUMMARY = "Mali450 libraries (drm backend)"
+
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/END_USER_LICENCE_AGREEMENT.txt;md5=3918cc9836ad038c5a090a0280233eea"
+
+COMPATIBLE_MACHINE = "hikey"
+
+SRC_URI[md5sum] = "36f39e86ccfe5a6a4cb2090865c339ba"
+SRC_URI[sha256sum] = "dd136931cdbb309c0ce30297c06f7c6b0a48450f51acbbbc10529d341977f728"
+
+PROVIDES += "virtual/egl virtual/libgles1 virtual/libgles2"
+
+DEPENDS = "libdrm wayland mesa"
+
+SRC_URI = " http://malideveloper.arm.com/downloads/drivers/binary/utgard/r6p0-01rel0/mali-450_${PV}-${PR}_linux_1+arm64.tar.gz;destsuffix=mali"
+
+S = "${WORKDIR}/wayland-drm"
+
+# The SRC is just a set of binaries to install - nothing to configure and to
+# compile
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -m 755 -d ${D}/${libdir}
+    install ${S}/libMali.so ${D}/${libdir}
+    (cd ${D}/${libdir} && ln -sf libMali.so libEGL.so.1.4 \
+    && ln -sf libEGL.so.1.4 libEGL.so.1 \
+    && ln -sf libEGL.so.1 libEGL.so)
+    (cd ${D}/${libdir} && ln -sf libMali.so libGLESv1_CM.so.1.1 \
+    && ln -sf libGLESv1_CM.so.1.1 libGLESv1_CM.so.1 \
+    && ln -sf libGLESv1_CM.so.1 libGLESv1_CM.so)
+    (cd ${D}/${libdir} && ln -sf libMali.so libGLESv2.so.2.0 \
+    && ln -sf libGLESv2.so.2.0 libGLESv2.so.2 \
+    && ln -sf libGLESv2.so.2 libGLESv2.so)
+    (cd ${D}/${libdir} && ln -sf libMali.so libgbm.so.1 \
+    && ln -sf libgbm.so.1 libgbm.so)
+    (cd ${D}/${libdir} && ln -sf libMali.so libwayland-egl.so)
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# The mali-450 driver tarball has only *.so files, so all the packages
+# except the ${PN} one would be empty
+FILES_${PN} += "${libdir}/*.so* "
+FILES_${PN}-dev = ""
+
+INSANE_SKIP_${PN} = "ldflags dev-so"
+
+# To get the egl/gles headers and the packageconfig files (missing from this
+# mali-450 driver tarball) we have to build mesa, and to handle the conflicts
+# due to both mali450-userland, and mesa providing the same libraries.
+RREPLACES_${PN} = "libegl libegl1 libgles1 libglesv1-cm1 libgles2 libglesv2-2 libgbm"
+RPROVIDES_${PN} = "libegl libegl1 libgles1 libglesv1-cm1 libgles2 libglesv2-2 libgbm"
+RCONFLICTS_${PN} = "libegl libegl1 libgles1 libglesv1-cm1 libgles2 libglesv2-2 libgbm"

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,0 +1,23 @@
+do_install_append_hikey() {
+    #because we cannot rely on the fact that all apps will use pkgconfig,
+    #make eglplatform.h independent of MESA_EGL_NO_X11_HEADER
+    if ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'true', 'false', d)}; then
+        sed -i -e 's/^#if defined(MESA_EGL_NO_X11_HEADERS)$/#if defined(MESA_EGL_NO_X11_HEADERS) || ${@bb.utils.contains('PACKAGECONFIG', 'x11', '0', '1', d)}/' ${D}${includedir}/EGL/eglplatform.h
+    fi
+
+    # Workarounds for Hikey board: remove the mesa libraries which duplicate
+    # the ones provided by mali450 driver
+
+    # remove EGL
+    rm -f ${D}/${libdir}/libEGL*
+    # remove GLESv1
+    rm -f ${D}/${libdir}/libGLESv1_CM.*
+    # remove GLESv2
+    rm -f ${D}/${libdir}/libGLESv2.*
+    # remove GBM
+    rm -f ${D}/${libdir}/libgbm.*
+    # remove Wayland-egl
+    rm -f ${D}/${libdir}/libwayland-egl.*
+}
+
+PROVIDES_remove_hikey = "virtual/libgles1 virtual/libgles2 virtual/egl"

--- a/recipes-graphics/wayland/weston/0001-force-software-cursor.patch
+++ b/recipes-graphics/wayland/weston/0001-force-software-cursor.patch
@@ -1,0 +1,18 @@
+diff --git a/src/compositor-drm.c b/src/compositor-drm.c
+index 6777bf8..81d3052 100644
+--- a/src/compositor-drm.c
++++ b/src/compositor-drm.c
+@@ -651,6 +651,13 @@ drm_output_repaint(struct weston_output *output_base,
+ 	if (!output->next)
+ 		return -1;
+ 
++  /* Workaround for Hikey page flip issue.
++   * Hikey page flip chokes on async atomic drm
++   *  page flip.
++   */
++
++  backend->cursors_are_broken = 1;
++
+ 	mode = container_of(output->base.current_mode, struct drm_mode, base);
+ 	if (!output->current ||
+ 	    output->current->stride != output->next->stride) {

--- a/recipes-graphics/wayland/weston_1.9.0.bbappend
+++ b/recipes-graphics/wayland/weston_1.9.0.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_hikey += "file://0001-force-software-cursor.patch "


### PR DESCRIPTION
Slightly updated version of the earlier pull request.
The changes are (omitted modifications to comments and commit headers):
----- 8< -----
--- a/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
+++ b/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
@@ -42,8 +42,8 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"

 # The mali-450 driver tarball has only _.so files, so all the packages
 # except the ${PN} one would be empty
-PACKAGES = "${PN}"
 FILES_${PN} += "${libdir}/_.so\* "
+FILES_${PN}-dev = ""
<snip>

--- a/recipes-graphics/wayland/weston_1.9.0.bbappend
+++ b/recipes-graphics/wayland/weston_1.9.0.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

-SRC_URI_append += "file://0001-force-software-cursor.patch "
+SRC_URI_append_hikey += "file://0001-force-software-cursor.patch "
----- 8< ----- 
