### PR TITLE
edk2-hikey: fix grub.cfg generation

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey/grub.cfg.in
+++ b/recipes-bsp/uefi/edk2-hikey/grub.cfg.in
@@ -1,9 +1,9 @@
 set default="0"
 set timeout=1
 
-menuentry 'CE Reference Platform (HiKey ${DISTRO})' {
+menuentry 'CE Reference Platform (HiKey @DISTRO)' {
     search.fs_label rootfs root
     set root=($root)
-    linux /boot/${KERNEL_IMAGETYPE} console=tty0 ${CMDLINE}
+    linux /boot/@KERNEL_IMAGETYPE console=tty0 @CMDLINE
     devicetree /boot/hi6220-hikey.dtb
 }

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -18,9 +18,9 @@ do_install() {
     install -D -p -m0644 ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ${D}/boot/EFI/BOOT/fastboot.efi
 
     # Install grub configuration
-    sed -e "s|\${DISTRO}|${DISTRO}|" \
-        -e "s|\${KERNEL_IMAGETYPE}|${KERNEL_IMAGETYPE}|" \
-        -e "s|\${CMDLINE}|${CMDLINE}|" \
+    sed -e "s|@DISTRO|${DISTRO}|" \
+        -e "s|@KERNEL_IMAGETYPE|${KERNEL_IMAGETYPE}|" \
+        -e "s|@CMDLINE|${CMDLINE}|" \
         < ${WORKDIR}/grub.cfg.in \
         > ${WORKDIR}/grub.cfg
     install -D -p -m0644 ${WORKDIR}/grub.cfg ${D}/boot/grub/grub.cfg


### PR DESCRIPTION
bitbake is replacing the environment variables so we can't use the form:
s|\${var}|${var}|

Use @ marker instead.

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
