### PR TITLE
hikey.conf: set the rootfs alignment to 4096 bytes and the label to "…

### DIFF
--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -40,7 +40,9 @@ CMDLINE_ROOT_EMMC = "/dev/disk/by-label/rootfs"
 CMDLINE_ROOT_SDCARD = "/dev/mmcblk1p2"
 CMDLINE ?= "console=ttyAMA3,115200n8 root=${CMDLINE_ROOT_EMMC} rootwait ro quiet efi=noruntime"
 
-# Fastboot expects an ext4 image
+# Fastboot expects an ext4 image, which needs to be 4096 bytes aligned
 IMAGE_FSTYPES_append = " ext4.gz"
+IMAGE_ROOTFS_ALIGNMENT = "4096"
+EXTRA_IMAGECMD_ext4 += " -L rootfs "
 
 EXTRA_IMAGEDEPENDS = "edk2-hikey l-loader grub"


### PR DESCRIPTION
…rootfs"
- Fastboot expects a 4096 bytes aligned image
- GRUB is searching for a root labeled "rootfs"

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
