### PR TITLE
edk2-hikey, l-loader: import bl1 via sysroot

### DIFF
--- a/recipes-bsp/l-loader/l-loader_git.bb
+++ b/recipes-bsp/l-loader/l-loader_git.bb
@@ -38,7 +38,9 @@ do_compile() {
     make
 }
 
-do_install[noexec] = "1"
+do_install() {
+    install -D -p -m0644 l-loader.bin ${D}${libdir}/l-loader/l-loader.bin
+}
 
 do_deploy() {
     install -D -p -m0644 l-loader.bin ${DEPLOY_DIR_IMAGE}/l-loader.bin

--- a/recipes-bsp/l-loader/l-loader_git.bb
+++ b/recipes-bsp/l-loader/l-loader_git.bb
@@ -27,14 +27,13 @@ S = "${WORKDIR}/git"
 
 do_configure[noexec] = "1"
 
-do_compile[depends] += "edk2-hikey:do_deploy"
 do_compile() {
     # Use pre-built aarch32 toolchain
     export PATH=${WORKDIR}/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf/bin:$PATH
 
     # bl1 from edk2 is required
     rm -f bl1.bin
-    ln -sf ${DEPLOY_DIR_IMAGE}/bl1.bin
+    ln -sf ${STAGING_LIBDIR}/edk2/bl1.bin
 
     make
 }

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -16,6 +16,9 @@ SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp 
 
 do_install() {
     install -D -p -m0644 ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ${D}/boot/EFI/BOOT/fastboot.efi
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${D}${libdir}/edk2/bl1.bin
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl2.bin ${D}${libdir}/edk2/bl2.bin
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${D}${libdir}/edk2/fip.bin
 
     # Install grub configuration
     sed -e "s|@DISTRO|${DISTRO}|" \
@@ -35,8 +38,6 @@ BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 # ensure we deploy grubaa64.efi before we try to create the boot image.
 do_deploy[depends] += "grub:do_deploy"
 do_deploy() {
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${DEPLOY_DIR_IMAGE}/bl1.bin
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl2.bin ${DEPLOY_DIR_IMAGE}/bl2.bin
     install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOY_DIR_IMAGE}/fip.bin
     install -D -p -m0644 ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ${DEPLOY_DIR_IMAGE}/fastboot.efi
 


### PR DESCRIPTION
The deploy dependency just doesn't work.

Signed-off-by: Koen Kooi koen.kooi@linaro.org
