### PR TITLE
edk2-hikey: clean up unused files

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -17,8 +17,6 @@ SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp 
 do_install() {
     install -D -p -m0644 ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ${D}/boot/EFI/BOOT/fastboot.efi
     install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${D}${libdir}/edk2/bl1.bin
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl2.bin ${D}${libdir}/edk2/bl2.bin
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${D}${libdir}/edk2/fip.bin
 
     # Install grub configuration
     sed -e "s|@DISTRO|${DISTRO}|" \
@@ -39,7 +37,6 @@ BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 do_deploy[depends] += "grub:do_deploy"
 do_deploy() {
     install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOY_DIR_IMAGE}/fip.bin
-    install -D -p -m0644 ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ${DEPLOY_DIR_IMAGE}/fastboot.efi
 
     # Ship nvme.img with UEFI binaries for convenience
     dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/nvme.img bs=128 count=1024
@@ -48,10 +45,10 @@ do_deploy() {
     mkfs.vfat -F32 -n "boot" -C ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${BOOT_IMAGE_SIZE}
     mmd -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI
     mmd -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI/BOOT
-    mcopy -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${DEPLOY_DIR_IMAGE}/fastboot.efi ::EFI/BOOT/fastboot.efi
+    mcopy -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ::EFI/BOOT/fastboot.efi
     mcopy -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${DEPLOY_DIR_IMAGE}/grubaa64.efi ::EFI/BOOT/grubaa64.efi
     chmod 644 ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img
-    rm -f ${DEPLOY_DIR_IMAGE}/*.efi
+    rm -f ${DEPLOY_DIR_IMAGE}/grubaa64.efi
 
     (cd ${DEPLOY_DIR_IMAGE} && ln -sf ${BOOT_IMAGE_BASE_NAME}.uefi.img boot-${MACHINE}.uefi.img)
 }


### PR DESCRIPTION
- only bl1.bin is needed to build l-loader
  it's shipped to the end users as part of fip.bin
- fastboot.efi doesn't need to be shipped standalone
  it's shipped to the end users as part of the boot image

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
