### PR TITLE
hikey.conf: add burn-boot (hisi-idt.py) to EXTRA_IMAGEDEPENDS

### DIFF
--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -46,4 +46,4 @@ IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 EXTRA_IMAGECMD_ext4 += " -L rootfs "
 
-EXTRA_IMAGEDEPENDS = "edk2-hikey l-loader grub"
+EXTRA_IMAGEDEPENDS = "edk2-hikey l-loader grub burn-boot"


### PR DESCRIPTION
Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
