### PR TITLE
edk2-hikey: include the secure payload (tee.bin) in the firmware imag…

### DIFF
--- a/recipes-bsp/uefi/edk2_git.bb
+++ b/recipes-bsp/uefi/edk2_git.bb
@@ -47,6 +47,7 @@ export LINKER = "${CC}"
 LDFLAGS = ""
 
 export UEFIMACHINE ?= "${MACHINE_ARCH}"
+OPTEE_OS_ARG ?= ""
 
 do_compile() {
     # Add in path to native sysroot to find uuid/uuid.h
@@ -54,7 +55,7 @@ do_compile() {
     # ... and the library itself
     sed -i -e 's: -luuid: -luuid -L ${STAGING_LIBDIR_NATIVE}:g' ${S}/BaseTools/Source/C/*/GNUmakefile
 
-    ${EDK2_DIR}/uefi-tools/uefi-build.sh -b RELEASE -a ${EDK2_DIR}/atf ${UEFIMACHINE}
+    ${EDK2_DIR}/uefi-tools/uefi-build.sh -b RELEASE -a ${EDK2_DIR}/atf ${OPTEE_OS_ARG} ${UEFIMACHINE}
 }
 
 do_deploy() {


### PR DESCRIPTION
…e package

We need the secure payload (Trusted OS) built from OP-TEE Trusted OS (tee.bin)
but we have already built tee.bin from optee-os recipe and
uefi-build.sh script has a few assumptions...
Copy tee.bin and create dummy files to make uefi-build.sh script happy

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
