### PR TITLE
hikey.conf: drop stale Xorg input drivers

### DIFF
--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -9,10 +9,9 @@ PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 XSERVER ?= "xserver-xorg \
             mesa-driver-swrast \
             xf86-input-evdev \
-            xf86-input-mouse \
             xf86-video-fbdev \
-            xf86-input-keyboard"
-
+           "
+           
 MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2 efi optee mali450"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-96boards"


### PR DESCRIPTION
Evdev handles everything, 'mouse' and 'keyboard' are deprecated.

Signed-off-by: Koen Kooi koen.kooi@linaro.org
