### PR TITLE
mali-userland: use anonymous method instead of COMPATIBLE_MACHINE

### DIFF
--- a/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
+++ b/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
@@ -3,7 +3,16 @@ SUMMARY = "ARM Mali Utgard GPU User Space driver for HiKey (drm backend)"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/END_USER_LICENCE_AGREEMENT.txt;md5=3918cc9836ad038c5a090a0280233eea"
 
-COMPATIBLE_MACHINE = "(hikey|hikey-32)"
+# Disable for non-MALI machines
+python __anonymous() {
+    features = bb.data.getVar("MACHINE_FEATURES", d, 1)
+    if not features:
+        return
+    if "mali450" not in features:
+        pkgn = bb.data.getVar("PN", d, 1)
+        pkgv = bb.data.getVar("PV", d, 1)
+        raise bb.parse.SkipPackage("%s-%s ONLY supports machines with a MALI iGPU" % (pkgn, pkgv))
+}
 
 SRC_URI[md5sum] = "36f39e86ccfe5a6a4cb2090865c339ba"
 SRC_URI[sha256sum] = "dd136931cdbb309c0ce30297c06f7c6b0a48450f51acbbbc10529d341977f728"


### PR DESCRIPTION
This makes it works for all machines that set 'mali450' without editing this recipe.

And as a bonus it gives a better error message:

```
[koen@thinkpad build-rpb]$ MACHINE=dragonboard-410c bitbake mali450-userland
Parsing recipes: 100% |###############################################################################| Time: 00:01:59
Parsing of 2364 .bb files complete (0 cached, 2364 parsed). 2994 targets, 191 skipped, 0 masked, 0 errors.
ERROR: Nothing PROVIDES 'mali450-userland'
ERROR: mali450-userland was skipped: mali450-userland-r6p0 ONLY supports machines with a MALI iGPU
```

Signed-off-by: Koen Kooi koen.kooi@linaro.org
