### PR TITLE
weston: Allow zero input devices; wait for graphics card

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,5 +1,9 @@
+inherit systemd
+
 SRC_URI += "file://weston.ini \
             file://weston-start \
+            file://weston.service \
+            file://weston-waitforcard.sh \
             "
 
 do_install_append() {
@@ -9,9 +13,17 @@ do_install_append() {
     install -Dm755 ${WORKDIR}/weston-start ${D}${bindir}/weston-start
     sed -i 's,@DATADIR@,${datadir},g' ${D}${bindir}/weston-start
     sed -i 's,@LOCALSTATEDIR@,${localstatedir},g' ${D}${bindir}/weston-start
+
+    sed -i -e s:/etc:${sysconfdir}:g \
+           -e s:/usr/bin:${bindir}:g \
+              ${WORKDIR}/weston.service
+    install -D -p -m0644 ${WORKDIR}/weston.service ${D}${systemd_unitdir}/system/weston.service
+    install -D -p -m0755 ${WORKDIR}/weston-waitforcard.sh ${D}${bindir}/weston-waitforcard.sh
 }
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 FILES_${PN} += "${sysconfdir}/xdg/weston/weston.ini"
 
 CONFFILES_${PN} += "${sysconfdir}/xdg/weston/weston.ini"
+
+SYSTEMD_SERVICE_${PN} = "weston.service"

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,7 +1,14 @@
-SRC_URI += "file://weston.ini"
+SRC_URI += "file://weston.ini \
+            file://weston-start \
+            "
 
 do_install_append() {
     install -D -p -m0644 ${WORKDIR}/weston.ini ${D}${sysconfdir}/xdg/weston/weston.ini
+
+    # Install weston-start script
+    install -Dm755 ${WORKDIR}/weston-start ${D}${bindir}/weston-start
+    sed -i 's,@DATADIR@,${datadir},g' ${D}${bindir}/weston-start
+    sed -i 's,@LOCALSTATEDIR@,${localstatedir},g' ${D}${bindir}/weston-start
 }
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/recipes-graphics/wayland/weston-init/weston-start
+++ b/recipes-graphics/wayland/weston-init/weston-start
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Copyright (C) 2016 O.S. Systems Software LTDA.
+# Copyright (C) 2016 Freescale Semiconductor
+
+export PATH="/sbin:/usr/sbin:/bin:/usr/bin"
+
+usage() {
+    cat <<EOF
+    $0 [<openvt arguments>] [-- <weston options>]
+EOF
+}
+
+## Module support
+modules_dir=@DATADIR@/weston-start
+
+# Add weston extra argument
+add_weston_argument() {
+	weston_args="$weston_args $1"
+}
+
+# Add openvt extra argument
+add_openvt_argument() {
+	openvt_args="$openvt_args $1"
+}
+
+if [ -n "$WAYLAND_DISPLAY" ]; then
+	echo "ERROR: A Wayland compositor is already running, nested Weston instance is not supported yet."
+	exit 1
+fi
+if [ -n "$DISPLAY" ]; then
+	launcher="weston"
+else
+	launcher="weston-launch --"
+fi
+
+openvt_args="-s"
+while [ -n "$1" ]; do
+	if [ "$1" = "--" ]; then
+		shift
+		break
+	fi
+	openvt_args="$openvt_args $1"
+	shift
+done
+
+weston_args=$*
+
+# Load and run modules
+if [ -d "$modules_dir" ]; then
+	for m in "$modules_dir"/*; do
+		# Skip backup files
+		if [ "`echo $m | sed -e 's/\~$//'`" != "$m" ]; then
+			continue
+		fi
+
+		# process module
+		. $m
+	done
+fi
+
+if test -z "$XDG_RUNTIME_DIR"; then
+    export XDG_RUNTIME_DIR=/run/user/`id -u`
+    if ! test -d "$XDG_RUNTIME_DIR"; then
+        mkdir --parents $XDG_RUNTIME_DIR
+        chmod 0700 $XDG_RUNTIME_DIR
+    fi
+fi
+
+exec openvt $openvt_args -- $launcher $weston_args --log=@LOCALSTATEDIR@/log/weston.log

--- a/recipes-graphics/wayland/weston-init/weston-waitforcard.sh
+++ b/recipes-graphics/wayland/weston-init/weston-waitforcard.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+DEFAULT_CARD=/dev/dri/card0
+DEFAULT_TIMEOUT=5
+
+if [ "$1"x = x ]; then
+    card=${DEFAULT_CARD}
+else
+    card=$1
+fi
+
+if [ "$2"x = x ]; then
+    timeout=${DEFAULT_TIMEOUT}
+else
+    timeout=$1
+fi
+
+ctr=0
+while true; do
+    echo "ctr=${ctr}"
+    if [ -e ${card} ]; then break; fi;
+    sleep 1
+    ctr=$(echo ${ctr} + 1 | bc)
+    if [ ${ctr} -ge ${timeout} ]; then
+      echo "Timeout waiting for ${card}"
+      exit 1
+    fi
+done

--- a/recipes-graphics/wayland/weston-init/weston.service
+++ b/recipes-graphics/wayland/weston-init/weston.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Weston Wayland Compositor
+RequiresMountsFor=/run
+
+[Service]
+User=root
+EnvironmentFile=-/etc/default/weston
+ExecStartPre=/usr/bin/weston-waitforcard.sh
+ExecStart=/usr/bin/weston-start -v -e -- $OPTARGS
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-graphics/wayland/weston/0001-libinput-seat-compositor-Don-t-fail-on-missing-devic.patch
+++ b/recipes-graphics/wayland/weston/0001-libinput-seat-compositor-Don-t-fail-on-missing-devic.patch
@@ -1,0 +1,48 @@
+From 7e0f54b1d49fac4dc9fd227f6b0741087db0b69f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Thu, 8 Sep 2016 10:43:42 -0500
+Subject: [PATCH] libinput-seat/compositor: Don't fail on missing devices.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It should be possible to run Weston without any initial
+input device. A sample use case for this is when running
+automated tests; another is when a user plugs an input
+device after launch.
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ src/compositor-drm.c | 2 +-
+ src/libinput-seat.c  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/compositor-drm.c b/src/compositor-drm.c
+index 6777bf8..71e16b6 100644
+--- a/src/compositor-drm.c
++++ b/src/compositor-drm.c
+@@ -3149,7 +3149,7 @@ drm_backend_create(struct weston_compositor *compositor,
+ 	if (udev_input_init(&b->input,
+ 			    compositor, b->udev, param->seat_id) < 0) {
+ 		weston_log("failed to create input devices\n");
+-		goto err_sprite;
++		/* goto err_sprite; */
+ 	}
+ 
+ 	if (create_outputs(b, param->connector, drm_device) < 0) {
+diff --git a/src/libinput-seat.c b/src/libinput-seat.c
+index c9f9ed2..7c84fe8 100644
+--- a/src/libinput-seat.c
++++ b/src/libinput-seat.c
+@@ -258,7 +258,7 @@ udev_input_enable(struct udev_input *input)
+ 			"\t- seats misconfigured "
+ 			"(Weston backend option 'seat', "
+ 			"udev device property ID_SEAT)\n");
+-		return -1;
++		return 0;
+ 	}
+ 
+ 	return 0;
+-- 
+1.9.1
+

--- a/recipes-graphics/wayland/weston_1.%.bbappend
+++ b/recipes-graphics/wayland/weston_1.%.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append_hikey = " file://0001-force-software-cursor.patch"
+SRC_URI_append_hikey = "file://0001-force-software-cursor.patch \
+                        file://0001-libinput-seat-compositor-Don-t-fail-on-missing-devic.patch \
+                        "


### PR DESCRIPTION
Two problems exist with Weston running immediately upon boot:
1. Weston requires an input device to exist; it's considered a fatal error if there's none. However, Weston works all right even if there isn't an input device, or if one appears later on.
2. Weston requires a graphics card to work. While this is not surprising, it might happen that due to the lightning-like speed of some 96boards and some rather weird timing, the /dev/dri/card0 device may not exist by the time Weston is launched.

These commits take care of those two issues by:
- patching Weston to allow zero input devices during launch,
- adding a systemd service that is launched upon boot (weston.service),
- adding a helper script (wait-for-card.sh) that will time out after 5 seconds if /dev/dri/card0 doesn't exist when running the systemd service unit.
