### PR TITLE
Weston: Launch on boot

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,5 +1,9 @@
+inherit systemd
+
 SRC_URI += "file://weston.ini \
             file://weston-start \
+            file://weston.service \
+            file://weston.path \
             "
 
 do_install_append() {
@@ -9,9 +13,17 @@ do_install_append() {
     install -Dm755 ${WORKDIR}/weston-start ${D}${bindir}/weston-start
     sed -i 's,@DATADIR@,${datadir},g' ${D}${bindir}/weston-start
     sed -i 's,@LOCALSTATEDIR@,${localstatedir},g' ${D}${bindir}/weston-start
+
+    sed -i -e s:/etc:${sysconfdir}:g \
+           -e s:/usr/bin:${bindir}:g \
+              ${WORKDIR}/weston.service
+    install -D -p -m0644 ${WORKDIR}/weston.service ${D}${systemd_unitdir}/system/weston.service
+    install -D -p -m0644 ${WORKDIR}/weston.path ${D}${systemd_unitdir}/system/weston.path
 }
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 FILES_${PN} += "${sysconfdir}/xdg/weston/weston.ini"
 
 CONFFILES_${PN} += "${sysconfdir}/xdg/weston/weston.ini"
+
+SYSTEMD_SERVICE_${PN} = "weston.service weston.path"

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,7 +1,14 @@
-SRC_URI += "file://weston.ini"
+SRC_URI += "file://weston.ini \
+            file://weston-start \
+            "
 
 do_install_append() {
     install -D -p -m0644 ${WORKDIR}/weston.ini ${D}${sysconfdir}/xdg/weston/weston.ini
+
+    # Install weston-start script
+    install -Dm755 ${WORKDIR}/weston-start ${D}${bindir}/weston-start
+    sed -i 's,@DATADIR@,${datadir},g' ${D}${bindir}/weston-start
+    sed -i 's,@LOCALSTATEDIR@,${localstatedir},g' ${D}${bindir}/weston-start
 }
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/recipes-graphics/wayland/weston-init/hikey/weston.ini
+++ b/recipes-graphics/wayland/weston-init/hikey/weston.ini
@@ -1,3 +1,6 @@
 [output]
 name=HDMI-A-1
 mode=current
+
+[libinput]
+require_input=false

--- a/recipes-graphics/wayland/weston-init/weston-start
+++ b/recipes-graphics/wayland/weston-init/weston-start
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Copyright (C) 2016 O.S. Systems Software LTDA.
+# Copyright (C) 2016 Freescale Semiconductor
+
+export PATH="/sbin:/usr/sbin:/bin:/usr/bin"
+
+usage() {
+    cat <<EOF
+    $0 [<openvt arguments>] [-- <weston options>]
+EOF
+}
+
+## Module support
+modules_dir=@DATADIR@/weston-start
+
+# Add weston extra argument
+add_weston_argument() {
+	weston_args="$weston_args $1"
+}
+
+# Add openvt extra argument
+add_openvt_argument() {
+	openvt_args="$openvt_args $1"
+}
+
+if [ -n "$WAYLAND_DISPLAY" ]; then
+	echo "ERROR: A Wayland compositor is already running, nested Weston instance is not supported yet."
+	exit 1
+fi
+if [ -n "$DISPLAY" ]; then
+	launcher="weston"
+else
+	launcher="weston-launch --"
+fi
+
+openvt_args="-s"
+while [ -n "$1" ]; do
+	if [ "$1" = "--" ]; then
+		shift
+		break
+	fi
+	openvt_args="$openvt_args $1"
+	shift
+done
+
+weston_args=$*
+
+# Load and run modules
+if [ -d "$modules_dir" ]; then
+	for m in "$modules_dir"/*; do
+		# Skip backup files
+		if [ "`echo $m | sed -e 's/\~$//'`" != "$m" ]; then
+			continue
+		fi
+
+		# process module
+		. $m
+	done
+fi
+
+if test -z "$XDG_RUNTIME_DIR"; then
+    export XDG_RUNTIME_DIR=/run/user/`id -u`
+    if ! test -d "$XDG_RUNTIME_DIR"; then
+        mkdir --parents $XDG_RUNTIME_DIR
+        chmod 0700 $XDG_RUNTIME_DIR
+    fi
+fi
+
+exec openvt $openvt_args -- $launcher $weston_args --log=@LOCALSTATEDIR@/log/weston.log

--- a/recipes-graphics/wayland/weston-init/weston.path
+++ b/recipes-graphics/wayland/weston-init/weston.path
@@ -1,0 +1,7 @@
+[Unit]
+Description=Graphic Card Watch
+Before=paths.target shutdown.target
+
+[Path]
+# DRM backend requires /dev/dri/card0
+PathExists=/dev/dri/card0

--- a/recipes-graphics/wayland/weston-init/weston.service
+++ b/recipes-graphics/wayland/weston-init/weston.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Weston Wayland Compositor
+RequiresMountsFor=/run
+Requires=weston.path
+
+[Service]
+User=root
+EnvironmentFile=-/etc/default/weston
+ExecStart=/usr/bin/weston-start -v -e -- $OPTARGS
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-graphics/wayland/weston/0001-Add-configuration-option-for-no-input-device.patch
+++ b/recipes-graphics/wayland/weston/0001-Add-configuration-option-for-no-input-device.patch
@@ -1,0 +1,73 @@
+From 10ae8aa7a8e60d618dcdd278644fbda9b5db94bc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Thu, 8 Sep 2016 10:43:42 -0500
+Subject: [PATCH] Add configuration option for no input device.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ src/compositor-drm.c | 9 ++++++++-
+ src/libinput-seat.c  | 8 +++++++-
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/compositor-drm.c b/src/compositor-drm.c
+index 6777bf8..8d2b8d5 100644
+--- a/src/compositor-drm.c
++++ b/src/compositor-drm.c
+@@ -3063,6 +3063,7 @@ drm_backend_create(struct weston_compositor *compositor,
+ 	struct wl_event_loop *loop;
+ 	const char *path;
+ 	uint32_t key;
++	int require_input;
+ 
+ 	weston_log("initializing drm backend\n");
+ 
+@@ -3146,10 +3147,16 @@ drm_backend_create(struct weston_compositor *compositor,
+ 	wl_list_init(&b->sprite_list);
+ 	create_sprites(b);
+ 
++	section = weston_config_get_section(config, "libinput", NULL, NULL);
++	weston_config_section_get_bool(section, "require_input",
++				       &require_input, 1);
++
+ 	if (udev_input_init(&b->input,
+ 			    compositor, b->udev, param->seat_id) < 0) {
+ 		weston_log("failed to create input devices\n");
+-		goto err_sprite;
++		if (require_input == 1) {
++			goto err_sprite;
++		}
+ 	}
+ 
+ 	if (create_outputs(b, param->connector, drm_device) < 0) {
+diff --git a/src/libinput-seat.c b/src/libinput-seat.c
+index c9f9ed2..b943f67 100644
+--- a/src/libinput-seat.c
++++ b/src/libinput-seat.c
+@@ -223,6 +223,8 @@ udev_input_enable(struct udev_input *input)
+ 	int fd;
+ 	struct udev_seat *seat;
+ 	int devices_found = 0;
++	struct weston_config_section *s;
++	int require_input;
+ 
+ 	loop = wl_display_get_event_loop(c->wl_display);
+ 	fd = libinput_get_fd(input->libinput);
+@@ -250,7 +252,11 @@ udev_input_enable(struct udev_input *input)
+ 			devices_found = 1;
+ 	}
+ 
+-	if (devices_found == 0) {
++	s = weston_config_get_section(c->config, "libinput", NULL, NULL);
++	weston_config_section_get_bool(s, "require_input",
++				       &require_input, 1);
++
++	if (devices_found == 0 && require_input == 1) {
+ 		weston_log(
+ 			"warning: no input devices on entering Weston. "
+ 			"Possible causes:\n"
+-- 
+1.9.1
+

--- a/recipes-graphics/wayland/weston_1.%.bbappend
+++ b/recipes-graphics/wayland/weston_1.%.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append_hikey = " file://0001-force-software-cursor.patch"
+SRC_URI_append_hikey = "file://0001-force-software-cursor.patch \
+                        file://0001-Add-configuration-option-for-no-input-device.patch \
+                        "


### PR DESCRIPTION
Add systemd service that launches Weston upon booting up.
Patch Weston so that considering a missing input device as a fatal error can be configured via weston.ini.

Tested on Hikey, Krogoth.
