### PR TITLE
Deploy rework

### DIFF
--- a/recipes-bsp/burn-boot/burn-boot_git.bb
+++ b/recipes-bsp/burn-boot/burn-boot_git.bb
@@ -15,8 +15,10 @@ do_install() {
 
 RDEPENDS_${PN} += "python-pyserial"
 
+inherit deploy
+
 do_deploy() {
-    install -D -p -m 0755 ${S}/hisi-idt.py ${DEPLOY_DIR_IMAGE}/hisi-idt.py
+    install -D -p -m 0755 ${S}/hisi-idt.py ${DEPLOYDIR}/hisi-idt.py
 }
 
 addtask deploy before do_build after do_compile

--- a/recipes-bsp/l-loader/l-loader_git.bb
+++ b/recipes-bsp/l-loader/l-loader_git.bb
@@ -44,8 +44,8 @@ do_install() {
 }
 
 do_deploy() {
-    install -D -p -m0644 l-loader.bin ${DEPLOY_DIR_IMAGE}/l-loader.bin
-    cp -a ptable-linux-*.img ${DEPLOY_DIR_IMAGE}
+    install -D -p -m0644 l-loader.bin ${DEPLOYDIR}/l-loader.bin
+    cp -a ptable-linux-*.img ${DEPLOYDIR}
 }
 
 addtask deploy before do_build after do_compile

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -54,19 +54,18 @@ BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 # ensure we deploy grubaa64.efi before we try to create the boot image.
 do_deploy[depends] += "grub:do_deploy"
 do_deploy() {
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOY_DIR_IMAGE}/fip.bin
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOYDIR}/fip.bin
 
     # Ship nvme.img with UEFI binaries for convenience
-    dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/nvme.img bs=128 count=1024
+    dd if=/dev/zero of=${DEPLOYDIR}/nvme.img bs=128 count=1024
 
     # Create boot image
-    mkfs.vfat -F32 -n "boot" -C ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${BOOT_IMAGE_SIZE}
-    mmd -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI
-    mmd -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI/BOOT
-    mcopy -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ::EFI/BOOT/fastboot.efi
-    mcopy -i ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${DEPLOY_DIR_IMAGE}/grubaa64.efi ::EFI/BOOT/grubaa64.efi
-    chmod 644 ${DEPLOY_DIR_IMAGE}/${BOOT_IMAGE_BASE_NAME}.uefi.img
-    rm -f ${DEPLOY_DIR_IMAGE}/grubaa64.efi
+    mkfs.vfat -F32 -n "boot" -C ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${BOOT_IMAGE_SIZE}
+    mmd -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI
+    mmd -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI/BOOT
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${EDK2_DIR}/Build/HiKey/RELEASE_GCC49/AARCH64/AndroidFastbootApp.efi ::EFI/BOOT/fastboot.efi
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${DEPLOY_DIR_IMAGE}/grubaa64.efi ::EFI/BOOT/grubaa64.efi
+    chmod 644 ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img
 
-    (cd ${DEPLOY_DIR_IMAGE} && ln -sf ${BOOT_IMAGE_BASE_NAME}.uefi.img boot-${MACHINE}.uefi.img)
+    (cd ${DEPLOYDIR} && ln -sf ${BOOT_IMAGE_BASE_NAME}.uefi.img boot-${MACHINE}.uefi.img)
 }


### PR DESCRIPTION
Rework deploy usage in bsp recipes to be race free and properly use sstate, this should fix:

```
10:56 <fabo> + mv fip.bin hisi-idt.py l-loader.bin nvme.img 'ptable-linux-*.img' bootloader/
10:56 <fabo> mv: cannot stat 'l-loader.bin': No such file or directory
10:56 <fabo> mv: cannot stat 'ptable-linux-*.img': No such file or directory
10:57 <fabo> on https://ci.linaro.org/job/96boards-reference-platform-openembedded-jethro/DISTRO=rpb,MACHINE=hikey,label=docker-jessie-amd64/61/consoleText
```

This PR is for master, needs both krogoth and jethro backports if accepted.
