### PR TITLE
Weston: no-input backported

### DIFF
--- a/recipes-graphics/wayland/weston-init/hikey/weston.ini
+++ b/recipes-graphics/wayland/weston-init/hikey/weston.ini
@@ -2,5 +2,5 @@
 name=HDMI-A-1
 mode=current
 
-[libinput]
-require_input=false
+[core]
+require-input=false

--- a/recipes-graphics/wayland/weston/0001-Add-configuration-option-for-no-input-device.patch
+++ b/recipes-graphics/wayland/weston/0001-Add-configuration-option-for-no-input-device.patch
@@ -1,73 +1,125 @@
-From 10ae8aa7a8e60d618dcdd278644fbda9b5db94bc Mon Sep 17 00:00:00 2001
+From 6c89292024cc08d4499916dc153c354175bd81c4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
-Date: Thu, 8 Sep 2016 10:43:42 -0500
+Date: Fri, 21 Oct 2016 14:03:13 -0500
 Subject: [PATCH] Add configuration option for no input device.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
----
- src/compositor-drm.c | 9 ++++++++-
- src/libinput-seat.c  | 8 +++++++-
- 2 files changed, 15 insertions(+), 2 deletions(-)
+[Backported from master, 75b7197.)
 
-diff --git a/src/compositor-drm.c b/src/compositor-drm.c
-index 6777bf8..8d2b8d5 100644
---- a/src/compositor-drm.c
-+++ b/src/compositor-drm.c
-@@ -3063,6 +3063,7 @@ drm_backend_create(struct weston_compositor *compositor,
- 	struct wl_event_loop *loop;
- 	const char *path;
- 	uint32_t key;
-+	int require_input;
+As it has been discussed in the past [1], running Weston
+without any input device at launch might be beneficial for
+some use cases.
+
+Certainly, it's best for the vast majority of users (and
+the project) to require an input device to be present, as
+to avoid frustration and hassle, but for those brave souls
+that so prefer, this patch lets them run without any input
+device at all.
+
+This introduces a simple configuration in weston.ini:
+  [core]
+  require-input=true
+
+True is the default, so no behavioral change is introduced.
+
+[1] https://lists.freedesktop.org/archives/wayland-devel/2015-November/025193.html
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+Reviewed-by: Peter Hutterer <peter.hutterer@who-t.net>
+Reviewed-by: Daniel Stone <daniels@collabora.com>
+---
+ man/weston.ini.man  | 5 +++++
+ src/compositor.h    | 4 ++++
+ src/libinput-seat.c | 6 ++++++
+ src/main.c          | 5 +++++
+ weston.ini.in       | 1 +
+ 5 files changed, 21 insertions(+)
+
+diff --git a/man/weston.ini.man b/man/weston.ini.man
+index a9b6026..668b16f 100644
+--- a/man/weston.ini.man
++++ b/man/weston.ini.man
+@@ -169,6 +169,11 @@ time, the one specified in the command-line will be used. On the other
+ hand, if none of these sets the value, default idle timeout will be
+ set to 300 seconds.
+ .RS
++.PP
++.RE
++.TP 7
++.BI "require-input=" true
++require an input device for launch
  
- 	weston_log("initializing drm backend\n");
+ .SH "LIBINPUT SECTION"
+ The
+diff --git a/src/compositor.h b/src/compositor.h
+index c4c81f0..292a412 100644
+--- a/src/compositor.h
++++ b/src/compositor.h
+@@ -701,6 +701,10 @@ struct weston_compositor {
  
-@@ -3146,10 +3147,16 @@ drm_backend_create(struct weston_compositor *compositor,
- 	wl_list_init(&b->sprite_list);
- 	create_sprites(b);
- 
-+	section = weston_config_get_section(config, "libinput", NULL, NULL);
-+	weston_config_section_get_bool(section, "require_input",
-+				       &require_input, 1);
+ 	void *user_data;
+ 	void (*exit)(struct weston_compositor *c);
 +
- 	if (udev_input_init(&b->input,
- 			    compositor, b->udev, param->seat_id) < 0) {
- 		weston_log("failed to create input devices\n");
--		goto err_sprite;
-+		if (require_input == 1) {
-+			goto err_sprite;
-+		}
- 	}
++	/* Whether to let the compositor run without any input device. */
++	bool require_input;
++
+ };
  
- 	if (create_outputs(b, param->connector, drm_device) < 0) {
+ struct weston_buffer {
 diff --git a/src/libinput-seat.c b/src/libinput-seat.c
-index c9f9ed2..b943f67 100644
+index c9f9ed2..1c4c358 100644
 --- a/src/libinput-seat.c
 +++ b/src/libinput-seat.c
-@@ -223,6 +223,8 @@ udev_input_enable(struct udev_input *input)
- 	int fd;
- 	struct udev_seat *seat;
- 	int devices_found = 0;
-+	struct weston_config_section *s;
-+	int require_input;
- 
- 	loop = wl_display_get_event_loop(c->wl_display);
- 	fd = libinput_get_fd(input->libinput);
-@@ -250,7 +252,11 @@ udev_input_enable(struct udev_input *input)
+@@ -250,6 +250,12 @@ udev_input_enable(struct udev_input *input)
  			devices_found = 1;
  	}
  
--	if (devices_found == 0) {
-+	s = weston_config_get_section(c->config, "libinput", NULL, NULL);
-+	weston_config_section_get_bool(s, "require_input",
-+				       &require_input, 1);
++	if (devices_found == 0 && !c->require_input) {
++		weston_log("warning: no input devices found, but none required "
++			   "as per configuration.\n");
++		return 0;
++	}
 +
-+	if (devices_found == 0 && require_input == 1) {
+ 	if (devices_found == 0) {
  		weston_log(
  			"warning: no input devices on entering Weston. "
- 			"Possible causes:\n"
+diff --git a/src/main.c b/src/main.c
+index a98570e..b8632e9 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -658,6 +658,7 @@ int main(int argc, char *argv[])
+ 	struct wl_client *primary_client;
+ 	struct wl_listener primary_client_destroyed;
+ 	struct weston_seat *seat;
++	int require_input;
+ 
+ 	const struct weston_option core_options[] = {
+ 		{ WESTON_OPTION_STRING, "backend", 'B', &backend },
+@@ -737,6 +738,10 @@ int main(int argc, char *argv[])
+ 	if (weston_compositor_init_config(ec, config) < 0)
+ 		goto out_signals;
+ 
++	weston_config_section_get_bool(section, "require-input",
++				       &require_input, true);
++	ec->require_input = require_input;
++
+ 	if (backend_init(ec, &argc, argv, config) < 0) {
+ 		weston_log("fatal: failed to create compositor backend\n");
+ 		goto out_signals;
+diff --git a/weston.ini.in b/weston.ini.in
+index 06b51df..e9ef992 100644
+--- a/weston.ini.in
++++ b/weston.ini.in
+@@ -2,6 +2,7 @@
+ #modules=xwayland.so,cms-colord.so
+ #shell=desktop-shell.so
+ #gbm-format=xrgb2101010
++#require-input=true
+ 
+ [shell]
+ background-image=/usr/share/backgrounds/gnome/Aqua.jpg
 -- 
 1.9.1
 


### PR DESCRIPTION
Use upstream version of no-input patch that allows Weston to run without an input device.
