### PR TITLE
weston-init: initiate PAM session for user root

### DIFF
--- a/recipes-graphics/wayland/weston-init/weston-start
+++ b/recipes-graphics/wayland/weston-init/weston-start
@@ -30,7 +30,7 @@ fi
 if [ -n "$DISPLAY" ]; then
 	launcher="weston"
 else
-	launcher="weston-launch --"
+	launcher="weston-launch -u root --"
 fi
 
 openvt_args="-s"


### PR DESCRIPTION
Some time ago (636156d), weston-launch used to set up the
session for user root as well, but this behavior was
changed to only set PAM up (and thus login environment,
such as the XDG variables) when instructed to be launched
as another user. This other user, however, can be root, and
all will be well.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>