### PR TITLE
hikey.conf: remove uim from MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS

### DIFF
--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -34,7 +34,6 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "linux-firmware \
                                         kernel-module-wlcore \
                                         kernel-module-wlcore-sdio \
                                         kernel-module-ti-conf-wl18xx \
-                                        uim \
                                        "
 
 CMDLINE_ROOT_EMMC   = "mmcblk0p9"


### PR DESCRIPTION
uim isn't needed anymore with 4.9 kernel. hciattach is used.
We still need TIInit_11.8.32.bts bluetooth firmware.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>