### PR TITLE
linux-hikey: update kernel to head

### DIFF
--- a/recipes-kernel/linux/linux-hikey/0001-thermal-hisilicon-use-dev_dbg-when-bind-sensors.patch
+++ b/recipes-kernel/linux/linux-hikey/0001-thermal-hisilicon-use-dev_dbg-when-bind-sensors.patch
@@ -1,0 +1,46 @@
+From c0c014f7409a9dd2d3a4d340f91cd1fab8b9846a Mon Sep 17 00:00:00 2001
+From: Leo Yan <leo.yan@linaro.org>
+Date: Thu, 16 Jun 2016 14:56:54 +0800
+Subject: [PATCH 1/1] thermal: hisilicon: use dev_dbg when bind sensors
+
+Current code use dev_err to output log if kernel cannot bind any one
+sensor in initialization. This is a strictly checking to make sure all
+four sensors have to be used for system.
+
+After enable thermal power allocator, usually system only use one sensor
+for multiple actors. This patch changes to use dev_dbg so that avoid
+confusion in boot log, and remove duplicate printing log.
+
+Signed-off-by: Leo Yan <leo.yan@linaro.org>
+---
+ drivers/thermal/hisi_thermal.c | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/thermal/hisi_thermal.c b/drivers/thermal/hisi_thermal.c
+index f642966..06baf72 100644
+--- a/drivers/thermal/hisi_thermal.c
++++ b/drivers/thermal/hisi_thermal.c
+@@ -260,7 +260,7 @@ static int hisi_thermal_register_sensor(struct platform_device *pdev,
+ 	if (IS_ERR(sensor->tzd)) {
+ 		ret = PTR_ERR(sensor->tzd);
+ 		sensor->tzd = NULL;
+-		dev_err(&pdev->dev, "failed to register sensor id %d: %d\n",
++		dev_dbg(&pdev->dev, "failed to register sensor id %d: %d\n",
+ 			sensor->id, ret);
+ 		return ret;
+ 	}
+@@ -351,10 +351,7 @@ static int hisi_thermal_probe(struct platform_device *pdev)
+ 	for (i = 0; i < HISI_MAX_SENSORS; ++i) {
+ 		ret = hisi_thermal_register_sensor(pdev, data,
+ 						   &data->sensors[i], i);
+-		if (ret)
+-			dev_err(&pdev->dev,
+-				"failed to register thermal sensor: %d\n", ret);
+-		else
++		if (!ret)
+ 			hisi_thermal_toggle_sensor(&data->sensors[i], true);
+ 	}
+ 
+-- 
+2.10.2
+

--- a/recipes-kernel/linux/linux-hikey_git.bb
+++ b/recipes-kernel/linux/linux-hikey_git.bb
@@ -3,7 +3,7 @@ require linux.inc
 DESCRIPTION = "96boards-hikey kernel"
 
 PV = "4.8+4.9-rc6+git${SRCPV}"
-SRCREV_kernel = "328d683059ec35c0359df2e58f8b0954fbf52ea5"
+SRCREV_kernel = "876b943b123dcc2d516ad12ce8bee5006de48321"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "git://github.com/Linaro/rpk.git;protocol=https;branch=master;name=kernel \
@@ -13,6 +13,7 @@ SRC_URI_append_hikey = " \
     file://defconfig;subdir=git/kernel/configs \
     file://mali-450.conf;subdir=git/kernel/configs \
     file://END_USER_LICENCE_AGREEMENT.txt;subdir=git \
+    file://0001-thermal-hisilicon-use-dev_dbg-when-bind-sensors.patch \
 "
 
 # Mali 400/450 GPU kernel device drivers license is GPLv2


### PR DESCRIPTION
* Update SRCREV to 876b943b
* Add a patch to use dev_dbg when bind sensors in hisi_thermal.
  It avoids the failed to register sensor messages.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>