### PR TITLE
edk2-hikey: update edk2/atf/openplatformpkg to RP 16.12 release and fix ATF build

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey/0001-ATF-fix-build-failure-with-gcc6.patch
+++ b/recipes-bsp/uefi/edk2-hikey/0001-ATF-fix-build-failure-with-gcc6.patch
@@ -1,0 +1,43 @@
+From b18589f8697f1d9f9ce6f97ec75a7026c14d4584 Mon Sep 17 00:00:00 2001
+From: Ronan <ronan.lemartret@iot.bzh>
+Date: Fri, 6 Jan 2017 17:55:47 +0100
+Subject: [PATCH] fix gcc 6.2 build
+
+ * prevent error, when gcc 6.2 is used:
+     "case label is not an integer constant expression"
+   from file :
+     "services/spd/opteed/opteed_main.c"
+   code:
+     "case TEESMC_OPTEED_RETURN_ON_DONE
+      case TEESMC_OPTEED_RETURN_RESUME_DONE
+      ..."
+   source error:
+    code:
+      ./services/spd/opteed/teesmc_opteed_macros.h
+    from TEESMC_OPTEED_RV: (SMC_TYPE_FAST << FUNCID_TYPE_SHIFT)
+
+   "
+   #define SMC_TYPE_FAST 1
+   #define FUNCID_TYPE_SHIFT 31
+   "
+
+ * ref:
+   http://c0x.coding-guidelines.com/6.5.7.html
+   https://github.com/ARM-software/tf-issues/issues/438
+
+Signed-off-by: Ronan <ronan.lemartret@iot.bzh>
+---
+ atf/include/bl31/runtime_svc.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/atf/include/bl31/runtime_svc.h
++++ b/atf/include/bl31/runtime_svc.h
+@@ -57,7 +57,7 @@
+ #define SMC_64				1
+ #define SMC_32				0
+ #define SMC_UNK				0xffffffff
+-#define SMC_TYPE_FAST			1
++#define SMC_TYPE_FAST			1U
+ #define SMC_TYPE_STD			0
+ #define SMC_PREEMPTED		0xfffffffe
+ /*******************************************************************************

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -12,6 +12,7 @@ SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp 
            git://github.com/96boards-hikey/arm-trusted-firmware.git;name=atf;branch=hikey;destsuffix=git/atf \
            git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=hikey-aosp;destsuffix=git/OpenPlatformPkg \
            file://grub.cfg.in \
+           file://0001-ATF-fix-build-failure-with-gcc6.patch \
           "
 
 OPTEE_OS_ARG = "-s ${EDK2_DIR}/optee_os"

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -4,9 +4,9 @@ COMPATIBLE_MACHINE = "hikey"
 
 DEPENDS_append = " dosfstools-native mtools-native grub optee-os"
 
-SRCREV_edk2 = "76c7cfcc22c7448638acb6f904088b2ff3f79f63"
-SRCREV_atf = "bdec62eeb8f3153a4647770e08aafd56a0bcd42b"
-SRCREV_openplatformpkg = "db64042266ed377f4a6748232497de8e05d36e35"
+SRCREV_edk2 = "9f98bde85b03fbd7e58f1190b08aeba80d76f97a"
+SRCREV_atf = "63655eba61d1739fd710f34fbe7ba8df3873ac4f"
+SRCREV_openplatformpkg = "f70886cd45a12a0ce961752de55dc70a878f8a15"
 
 SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp \
            git://github.com/96boards-hikey/arm-trusted-firmware.git;name=atf;branch=hikey;destsuffix=git/atf \


### PR DESCRIPTION
update edk2/atf/openplatformpkg to RP 16.12 release
add patch fix ATF build failure with GCC 6