### PR TITLE
linux-bubblegum: workaround build failure with GCC 6

### DIFF
--- a/recipes-kernel/linux/linux-bubblegum_3.10.bb
+++ b/recipes-kernel/linux/linux-bubblegum_3.10.bb
@@ -41,6 +41,10 @@ do_configure() {
     echo '# CONFIG_RTL8723BU is not set' >> ${B}/.config 
     echo '# CONFIG_RTL8723BS is not set' >> ${B}/.config 
 
+    # Workaround build failure with GCC6:
+    # Don't build ARM AMBA Multimedia Card Interface support as a module
+    sed -i -e '/CONFIG_MMC_ARMMMCI/d' ${B}/.config
+    echo 'CONFIG_MMC_ARMMMCI=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:


### PR DESCRIPTION
Don't build ARM AMBA Multimedia Card Interface support as a module.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>