### PR TITLE
[morty] weston: run as user

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,26 +1,30 @@
 inherit systemd
 
 SRC_URI += "file://weston.ini \
-            file://weston.service \
+            file://weston@.service \
             file://71-weston-drm.rules \
 "
 
 do_install_append() {
     install -D -p -m0644 ${WORKDIR}/weston.ini ${D}${sysconfdir}/xdg/weston/weston.ini
 
+    # Remove upstream weston.service
+    rm ${D}${systemd_unitdir}/system/weston.service
+
     # Install Weston systemd service and accompanying udev rule
-    install -D -p -m0644 ${WORKDIR}/weston.service ${D}${systemd_unitdir}/system/weston.service
+    install -D -p -m0644 ${WORKDIR}/weston@.service ${D}${systemd_unitdir}/system/weston@.service
     sed -i -e s:/etc:${sysconfdir}:g \
            -e s:/usr/bin:${bindir}:g \
            -e s:/var:${localstatedir}:g \
-              ${D}${systemd_unitdir}/system/weston.service
+              ${D}${systemd_unitdir}/system/weston@.service
     install -D -p -m0644 ${WORKDIR}/71-weston-drm.rules \
         ${D}${sysconfdir}/udev/rules.d/71-weston-drm.rules
 }
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-FILES_${PN} += "${sysconfdir}/xdg/weston/weston.ini"
+FILES_${PN} += "${sysconfdir}/xdg/weston/weston.ini ${systemd_unitdir}/system/weston@.service"
 
 CONFFILES_${PN} += "${sysconfdir}/xdg/weston/weston.ini"
 
-SYSTEMD_SERVICE_${PN} = "weston.service"
+SYSTEMD_SERVICE_${PN} = "weston@%i.service"
+SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-graphics/wayland/weston-init/71-weston-drm.rules
+++ b/recipes-graphics/wayland/weston-init/71-weston-drm.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="drm", KERNEL=="card0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="weston.service"
+ACTION=="add", SUBSYSTEM=="drm", KERNEL=="card0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="weston@linaro.service"

--- a/recipes-graphics/wayland/weston-init/hikey/weston.ini
+++ b/recipes-graphics/wayland/weston-init/hikey/weston.ini
@@ -2,5 +2,5 @@
 name=HDMI-A-1
 mode=current
 
-[libinput]
-require_input=false
+[core]
+require-input=false

--- a/recipes-graphics/wayland/weston-init/weston@.service
+++ b/recipes-graphics/wayland/weston-init/weston@.service
@@ -5,7 +5,7 @@ Conflicts=getty@tty7.service plymouth-quit.service
 After=systemd-user-sessions.service getty@tty7.service plymouth-quit-wait.service
 
 [Service]
-User=root
+User=%i
 PermissionsStartOnly=true
 
 # Log us in via PAM so we get our XDG & co. environment and
@@ -29,7 +29,7 @@ EnvironmentFile=-/etc/default/weston
 # Weston does not successfully change VT, nor does systemd place us on
 # the VT it just activated for us. Switch manually:
 ExecStartPre=/usr/bin/chvt 7
-ExecStart=/usr/bin/weston --log=/var/log/weston.log $OPTARGS
+ExecStart=/usr/bin/weston --log=${XDG_RUNTIME_DIR}/weston.log $OPTARGS
 
 IgnoreSIGPIPE=no
 


### PR DESCRIPTION
Run Weston as a regular user instead of root.

Changes involved:
* assign /dev/mali to group video,
* convert Weston systemd service unit to template,
* update no-input configuration as per upstream.

Needed elsewhere:
* add user linaro to group video, in meta-rpb/recipes-samples/images/rpb-weston-image.bb.

Weston logs are now in ${XDG_RUNTIME_DIR}/weston.log instead of /var/log/weston.log.