### PR TITLE
edk2-hikey: remove fip.bin install

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -54,8 +54,6 @@ BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 # ensure we deploy grubaa64.efi before we try to create the boot image.
 do_deploy[depends] += "grub:do_deploy"
 do_deploy() {
-    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOYDIR}/fip.bin
-
     # Ship nvme.img with UEFI binaries for convenience
     dd if=/dev/zero of=${DEPLOYDIR}/nvme.img bs=128 count=1024
 

--- a/recipes-bsp/uefi/edk2_git.bb
+++ b/recipes-bsp/uefi/edk2_git.bb
@@ -62,7 +62,7 @@ do_deploy() {
     # Placeholder to be implemented in machine specific recipe
 
     if [ -e ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ] ; then 
-    	install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOYDIR}/fip.bin
+        install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin ${DEPLOYDIR}/fip.bin
     fi
 }
 


### PR DESCRIPTION
Since commit 9f548e0b4a01c9cb92d13f352e57d88f88640d54
fip.bin is installed from the generic edk2 recipe.
It isn't needed in the HiKey specific edk2 recipe.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>