### PR TITLE
edk2-hikey: do_deploy -> do_deploy_append

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -53,7 +53,7 @@ BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 # HiKey boot image requires fastboot and grub EFI
 # ensure we deploy grubaa64.efi before we try to create the boot image.
 do_deploy[depends] += "grub:do_deploy"
-do_deploy() {
+do_deploy_append() {
     # Ship nvme.img with UEFI binaries for convenience
     dd if=/dev/zero of=${DEPLOYDIR}/nvme.img bs=128 count=1024
 


### PR DESCRIPTION
Since we do actions in the generic edk2 do_deploy(),
the machine specific recipe should use do_deploy_append().

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>