### PR TITLE
linux-armlt: set rebaseable tag

### DIFF
--- a/recipes-kernel/linux/linux-armlt_git.bb
+++ b/recipes-kernel/linux/linux-armlt_git.bb
@@ -6,7 +6,7 @@ PV = "4.9.0+git"
 SRCREV_kernel = "bd4ec9ac3787a05c0e6878e09aa8d2b66dd3f80d"
 SRCREV_FORMAT = "kernel"
 
-SRC_URI = "git://git.linaro.org/landing-teams/working/arm/kernel-release.git;protocol=https;branch=latest-armlt;name=kernel \
+SRC_URI = "git://git.linaro.org/landing-teams/working/arm/kernel-release.git;protocol=https;branch=latest-armlt;name=kernel;rebaseable=1 \
           "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
 to be able to get old tags that dropped of the branch.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>