### PR TITLE
linux-hikey960: fix the whitespace error in the recipe

### DIFF
--- a/recipes-kernel/linux/linux-hikey960_git.bb
+++ b/recipes-kernel/linux/linux-hikey960_git.bb
@@ -60,7 +60,7 @@ do_configure() {
 
 # Exclude DATETIME for signatures to avoid invalidating them during a build
 BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
-DT_IMAGE_BASE_NAME [vardepsexclude] = "DATETIME"
+DT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 
 BOOT_IMAGE_BASE_NAME = "boot-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
 DT_IMAGE_BASE_NAME = "dt-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"


### PR DESCRIPTION
commit 9b34cb74ebed3d5068b58642f929919748e776c9 introduced
an extra space character which broke the builds.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>