### PR TITLE
hikey: use linux-firmware-wl12xx/wl18xx instead of linux-firmware-wl12xx

### DIFF
--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -27,7 +27,8 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "\
     grub \
 "
 
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "linux-firmware \
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "linux-firmware-wl12xx \
+                                        linux-firmware-wl18xx \
                                         kernel-module-btwilink \
                                         kernel-module-st-drv \
                                         kernel-module-wl18xx \

--- a/conf/machine/hikey960.conf
+++ b/conf/machine/hikey960.conf
@@ -25,7 +25,8 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "\
     grub \
 "
 
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "linux-firmware \
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "linux-firmware-wl12xx \
+                                        linux-firmware-wl18xx \
                                         kernel-module-btwilink \
                                         kernel-module-st-drv \
                                         kernel-module-wl18xx \


### PR DESCRIPTION
Reduce the size of HiKey and HiKey960 image by installing wl12xx/wl18xx
firmwares only, instead of all linux firmwares.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>