### PR TITLE
recipes-bsp: grub: fix gcc compilers with pie turned on by default

### DIFF
--- a/recipes-bsp/grub/grub-git/0001-configure-add-check-for-no-pie-if-the-compiler-defau.patch
+++ b/recipes-bsp/grub/grub-git/0001-configure-add-check-for-no-pie-if-the-compiler-defau.patch
@@ -1,0 +1,79 @@
+From a3e9da054d00260f274cfd9d1b9611c32ecd437c Mon Sep 17 00:00:00 2001
+From: Magnus Granberg <zorry@gentoo.org>
+Date: Wed, 14 Dec 2016 20:44:41 +0300
+Subject: [PATCH] configure: add check for -no-pie if the compiler default to
+ -fPIE
+
+When Grub is compile with gcc 6.1 that have --enable-defult-pie set.
+It fail with.
+-ffreestanding   -m32 -Wl,-melf_i386 -Wl,--build-id=none  -nostdlib -Wl,-N -Wl,-r,-d   -
+o trig.module  trig_module-trigtables.o
+grep 'MARKER' gcry_whirlpool.marker.new > gcry_whirlpool.marker; rm -f
+gcry_whirlpool.marker.new
+/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: -r and -
+shared may not be used together
+collect2: error: ld returned 1 exit status
+Makefile:26993: recipe for target 'trig.module' failed
+
+Check that compiler supports -no-pie and add it to linker flags.
+---
+ acinclude.m4 | 18 ++++++++++++++++++
+ configure.ac |  7 ++++++-
+ 2 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index 526f97a..7884c1b 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -390,6 +390,24 @@ else
+ [fi]
+ ])
+ 
++dnl Check if the Linker supports `-no-pie'.
++AC_DEFUN([grub_CHECK_NO_PIE],
++[AC_MSG_CHECKING([whether linker accepts -no-pie])
++AC_CACHE_VAL(grub_cv_cc_ld_no_pie,
++[save_LDFLAGS="$LDFLAGS"
++LDFLAGS="$LDFLAGS -no-pie"
++AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
++	       [grub_cv_cc_ld_no_pie=yes],
++	       [grub_cv_cc_ld_no_pie=no])
++LDFLAGS="$save_LDFLAGS"
++])
++AC_MSG_RESULT([$grub_cv_cc_ld_no_pie])
++nopie_possible=no
++if test "x$grub_cv_cc_ld_no_pie" = xyes ; then
++  nopie_possible=yes
++fi
++])
++
+ dnl Check if the C compiler supports `-fPIC'.
+ AC_DEFUN([grub_CHECK_PIC],[
+ [# Position independent executable.
+diff --git a/configure.ac b/configure.ac
+index 3d25510..dc56564 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1185,13 +1185,18 @@ CFLAGS="$TARGET_CFLAGS"
+ 
+ # Position independent executable.
+ grub_CHECK_PIE
++grub_CHECK_NO_PIE
+ [# Need that, because some distributions ship compilers that include
+-# `-fPIE' or '-fpie' in the default specs.
++# `-fPIE' or '-fpie' and '-pie' in the default specs.
+ if [ x"$pie_possible" = xyes ]; then
+   TARGET_CFLAGS="$TARGET_CFLAGS -fno-PIE -fno-pie"
++fi
++if [ x"$nopie_possible" = xyes ] &&  [ x"$pie_possible" = xyes ]; then
++  TARGET_LDFLAGS="$TARGET_LDFLAGS -no-pie"
+ fi]
+ 
+ CFLAGS="$TARGET_CFLAGS"
++LDFLAGS="$TARGET_LDFLAGS"
+ 
+ # Position independent executable.
+ grub_CHECK_PIC
+-- 
+2.9.3
+

--- a/recipes-bsp/grub/grub_git.bb
+++ b/recipes-bsp/grub/grub_git.bb
@@ -13,6 +13,7 @@ SRCREV = "b524fa27f56381bb0efa4944e36f50265113aee5"
 SRC_URI = "git://git.savannah.gnu.org/grub.git \
            file://autogen.sh-exclude-pc.patch \
            file://0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch \
+           file://0001-configure-add-check-for-no-pie-if-the-compiler-defau.patch \
            file://cfg \
           "
 


### PR DESCRIPTION
When building on Ubuntu 16.10+, gcc has pie turned on by default.
This causes the grub build step to fail with an LD error complaining
about 2 conflicting settings.

This has been fixed upstream, so let's pull that patch in:
http://git.savannah.gnu.org/cgit/grub.git/commit/?id=a3e9da054d00260f274cfd9d1b9611c32ecd437c

Signed-off-by: Michael Scott <michael.scott@linaro.org>