### PR TITLE
linux-hikey: generate and publish savedeconfig output

### DIFF
--- a/recipes-kernel/linux/linux-hikey-aosp_git.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_git.bb
@@ -59,4 +59,8 @@ do_configure() {
     oe_runmake -C ${S} O=${B} kselftest-merge
 
     yes '' | oe_runmake -C ${S} O=${B} oldconfig
+
+    bbplain "Saving defconfig to:\n${B}/defconfig"
+    oe_runmake -C ${B} savedefconfig
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey960_git.bb
+++ b/recipes-kernel/linux/linux-hikey960_git.bb
@@ -56,6 +56,10 @@ do_configure() {
     fi
 
     yes '' | oe_runmake -C ${S} O=${B} oldconfig
+
+    bbplain "Saving defconfig to:\n${B}/defconfig"
+    oe_runmake -C ${B} savedefconfig
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }
 
 # Exclude DATETIME for signatures to avoid invalidating them during a build

--- a/recipes-kernel/linux/linux-hikey_git.bb
+++ b/recipes-kernel/linux/linux-hikey_git.bb
@@ -91,4 +91,8 @@ do_configure() {
     fi
 
     yes '' | oe_runmake -C ${S} O=${B} oldconfig
+
+    bbplain "Saving defconfig to:\n${B}/defconfig"
+    oe_runmake -C ${B} savedefconfig
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }


### PR DESCRIPTION
Convenient for kernel developers to pick up only the kernel configuration.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>