### PR TITLE
edk2-hikey: ignore QA error caused by bl1.bin not shipped

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -14,6 +14,9 @@ SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp 
            file://grub.cfg.in \
           "
 
+# /usr/lib/edk2/bl1.bin not shipped files. [installed-vs-shipped]
+INSANE_SKIP_${PN} += "installed-vs-shipped"
+
 OPTEE_OS_ARG = "-s ${EDK2_DIR}/optee_os"
 
 # We need the secure payload (Trusted OS) built from OP-TEE Trusted OS (tee.bin)


### PR DESCRIPTION
On some distro (e.g. poky), installed-vs-shipped is a QA error.
Avoid to trigger the error on these distros.
bl1.bin is required by l-loader but built by edk2-hikey recipe.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>