### PR TITLE
grub: fix NoneType error when the recipe is used on other boards than…

### DIFF
--- a/recipes-bsp/grub/grub_git.bb
+++ b/recipes-bsp/grub/grub_git.bb
@@ -14,11 +14,8 @@ SRC_URI = "git://git.savannah.gnu.org/grub.git \
            file://autogen.sh-exclude-pc.patch \
            file://0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch \
            file://0001-configure-add-check-for-no-pie-if-the-compiler-defau.patch \
-          "
-
-SRC_URI_append_hikey = " \
-    file://cfg.emmc \
-    file://cfg.sdcard \
+           file://cfg.emmc \
+           file://cfg.sdcard \
 "
 
 S = "${WORKDIR}/git"
@@ -72,13 +69,14 @@ do_install_append () {
 GRUB_BUILDIN ?= "boot chain configfile echo efinet eval ext2 fat font gettext gfxterm gzio help linux loadenv lsefi normal part_gpt part_msdos read regexp search search_fs_file search_fs_uuid search_label terminal terminfo test tftp time"
 
 python () {
-    emmc = d.getVar('CMDLINE_ROOT_EMMC', True)
-    cmdline = d.getVar('CMDLINE', True)
+    grub_cfg = 'cfg.emmc'
 
-    if emmc in cmdline:
-        d.setVar('GRUB_CFG', 'cfg.emmc')
-    else:
-        d.setVar('GRUB_CFG', 'cfg.sdcard')
+    sdcard = d.getVar('CMDLINE_ROOT_SDCARD', True)
+    cmdline = d.getVar('CMDLINE', True)
+    if sdcard is not None and sdcard in cmdline:
+        grub_cfg = 'cfg.sdcard'
+
+    d.setVar('GRUB_CFG', grub_cfg)
 }
 
 do_deploy() {


### PR DESCRIPTION
… HiKey

If the recipe is used by other boards than Hikey, it triggers an
exception because the CMDLINE_ROOT_* variables aren't always set:
Exception: TypeError: argument of type 'NoneType' is not iterable

Make sure we ship default cfg files, even if they are HiKey specific.
Rework the function to set GRUB_CFG: set a default value to grub_cfg, add
a test to check if our variable isn't None.

Layer that override the recipe can just have a SRC_URI_append with their
own cfg files and invoke do_deploy_prepend() to set GRUB_CFG as they wish.

Reported-by: Ricardo Salveti <ricardo.salveti@linaro.org>
Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>