### PR TITLE
Fix grub with gcc7 and new hardening structure for oe-core and fix edk2 in a multi-bsp environment

### DIFF
--- a/recipes-bsp/grub/grub-git/0001-Enforce-no-pie-if-the-compiler-supports-it.patch
+++ b/recipes-bsp/grub/grub-git/0001-Enforce-no-pie-if-the-compiler-supports-it.patch
@@ -1,0 +1,42 @@
+From 6186bcf1bcaaa0f16e79339e07c64c841d4d957d Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 2 Dec 2016 20:52:40 +0200
+Subject: [PATCH] Enforce -no-pie, if the compiler supports it.
+
+Add a -no-pie as recent (2 Dec 2016) Debian testing compiler
+seems to default to enabling PIE when linking. See
+https://wiki.ubuntu.com/SecurityTeam/PIE
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ acinclude.m4 | 2 +-
+ configure.ac | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+Index: git/acinclude.m4
+===================================================================
+--- git.orig/acinclude.m4
++++ git/acinclude.m4
+@@ -426,7 +426,7 @@ int main() {
+ 
+ [# `$CC -c -o ...' might not be portable.  But, oh, well...  Is calling
+ # `ac_compile' like this correct, after all?
+-if eval "$ac_compile -S -o conftest.s" 2> /dev/null; then]
++if eval "$ac_compile -S -o conftest.s" 2> /dev/null && eval "$CC -dumpspecs 2>/dev/null | grep -e no-pie" ; then]
+   AC_MSG_RESULT([yes])
+   [# Should we clear up other files as well, having called `AC_LANG_CONFTEST'?
+   rm -f conftest.s
+Index: git/configure.ac
+===================================================================
+--- git.orig/configure.ac
++++ git/configure.ac
+@@ -1189,7 +1189,7 @@ grub_CHECK_NO_PIE
+ [# Need that, because some distributions ship compilers that include
+ # `-fPIE' or '-fpie' and '-pie' in the default specs.
+ if [ x"$pie_possible" = xyes ]; then
+-  TARGET_CFLAGS="$TARGET_CFLAGS -fno-PIE -fno-pie"
++  TARGET_CFLAGS="$TARGET_CFLAGS -fno-PIE -no-pie"
+ fi
+ if [ x"$nopie_possible" = xyes ] &&  [ x"$pie_possible" = xyes ]; then
+   TARGET_LDFLAGS="$TARGET_LDFLAGS -no-pie"

--- a/recipes-bsp/grub/grub-git/0001-btrfs-avoid-used-uninitialized-error-with-GCC7.patch
+++ b/recipes-bsp/grub/grub-git/0001-btrfs-avoid-used-uninitialized-error-with-GCC7.patch
@@ -1,0 +1,33 @@
+From 6d4ea77c59f000e371202d7231f873154a6feca5 Mon Sep 17 00:00:00 2001
+From: Andrei Borzenkov <arvidjaar@gmail.com>
+Date: Tue, 4 Apr 2017 19:22:32 +0300
+Subject: [PATCH 1/2] btrfs: avoid "used uninitialized" error with GCC7
+
+sblock was local and so considered new variable on every loop
+iteration.
+
+Closes: 50597
+---
+ grub-core/fs/btrfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/fs/btrfs.c b/grub-core/fs/btrfs.c
+index 9cffa91fa..4849c1ceb 100644
+--- a/grub-core/fs/btrfs.c
++++ b/grub-core/fs/btrfs.c
+@@ -227,11 +227,11 @@ grub_btrfs_read_logical (struct grub_btrfs_data *data,
+ static grub_err_t
+ read_sblock (grub_disk_t disk, struct grub_btrfs_superblock *sb)
+ {
++  struct grub_btrfs_superblock sblock;
+   unsigned i;
+   grub_err_t err = GRUB_ERR_NONE;
+   for (i = 0; i < ARRAY_SIZE (superblock_sectors); i++)
+     {
+-      struct grub_btrfs_superblock sblock;
+       /* Don't try additional superblocks beyond device size.  */
+       if (i && (grub_le_to_cpu64 (sblock.this_device.size)
+ 		>> GRUB_DISK_SECTOR_BITS) <= superblock_sectors[i])
+-- 
+2.13.2
+

--- a/recipes-bsp/grub/grub-git/0002-i386-x86_64-ppc-fix-switch-fallthrough-cases-with-GC.patch
+++ b/recipes-bsp/grub/grub-git/0002-i386-x86_64-ppc-fix-switch-fallthrough-cases-with-GC.patch
@@ -1,0 +1,313 @@
+From e6cab1be34b8d2c40d14fac81cc86d10e8e8667a Mon Sep 17 00:00:00 2001
+From: Andrei Borzenkov <arvidjaar@gmail.com>
+Date: Tue, 4 Apr 2017 19:23:55 +0300
+Subject: [PATCH 2/2] i386, x86_64, ppc: fix switch fallthrough cases with GCC7
+
+In util/getroot and efidisk slightly modify exitsing comment to mostly
+retain it but still make GCC7 compliant with respect to fall through
+annotation.
+
+In grub-core/lib/xzembed/xz_dec_lzma2.c it adds same comments as
+upstream.
+
+In grub-core/tests/setjmp_tets.c declare functions as "noreturn" to
+suppress GCC7 warning.
+
+In grub-core/gnulib/regexec.c use new __attribute__, because existing
+annotation is not recognized by GCC7 parser (which requires that comment
+immediately precedes case statement).
+
+Otherwise add FALLTHROUGH comment.
+
+Closes: 50598
+---
+ grub-core/commands/hdparm.c           | 1 +
+ grub-core/commands/nativedisk.c       | 1 +
+ grub-core/disk/cryptodisk.c           | 1 +
+ grub-core/disk/efi/efidisk.c          | 2 +-
+ grub-core/efiemu/mm.c                 | 1 +
+ grub-core/gdb/cstub.c                 | 1 +
+ grub-core/gnulib/regexec.c            | 3 +++
+ grub-core/lib/xzembed/xz_dec_lzma2.c  | 4 ++++
+ grub-core/lib/xzembed/xz_dec_stream.c | 6 ++++++
+ grub-core/loader/i386/linux.c         | 3 +++
+ grub-core/tests/setjmp_test.c         | 5 ++++-
+ grub-core/video/ieee1275.c            | 1 +
+ grub-core/video/readers/jpeg.c        | 1 +
+ util/getroot.c                        | 2 +-
+ util/grub-install.c                   | 1 +
+ util/grub-mkimagexx.c                 | 1 +
+ util/grub-mount.c                     | 1 +
+ 17 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/commands/hdparm.c b/grub-core/commands/hdparm.c
+index f6b178eae..d3fa9661e 100644
+--- a/grub-core/commands/hdparm.c
++++ b/grub-core/commands/hdparm.c
+@@ -328,6 +328,7 @@ grub_cmd_hdparm (grub_extcmd_context_t ctxt, int argc, char **args)
+ 	  ata = ((struct grub_scsi *) disk->data)->data;
+ 	  break;
+ 	}
++      /* FALLTHROUGH */
+     default:
+       grub_disk_close (disk);
+       return grub_error (GRUB_ERR_IO, "not an ATA device");
+diff --git a/grub-core/commands/nativedisk.c b/grub-core/commands/nativedisk.c
+index 345f97c4d..2f56a870e 100644
+--- a/grub-core/commands/nativedisk.c
++++ b/grub-core/commands/nativedisk.c
+@@ -79,6 +79,7 @@ get_uuid (const char *name, char **uuid, int getnative)
+     case GRUB_DISK_DEVICE_XEN:
+       if (getnative)
+ 	break;
++      /* FALLTHROUGH */
+ 
+       /* Virtual disks.  */
+       /* GRUB dynamically generated files.  */
+diff --git a/grub-core/disk/cryptodisk.c b/grub-core/disk/cryptodisk.c
+index 1e03a091c..bd60a66b3 100644
+--- a/grub-core/disk/cryptodisk.c
++++ b/grub-core/disk/cryptodisk.c
+@@ -282,6 +282,7 @@ grub_cryptodisk_endecrypt (struct grub_cryptodisk *dev,
+ 	  break;
+ 	case GRUB_CRYPTODISK_MODE_IV_PLAIN64:
+ 	  iv[1] = grub_cpu_to_le32 (sector >> 32);
++	  /* FALLTHROUGH */
+ 	case GRUB_CRYPTODISK_MODE_IV_PLAIN:
+ 	  iv[0] = grub_cpu_to_le32 (sector & 0xFFFFFFFF);
+ 	  break;
+diff --git a/grub-core/disk/efi/efidisk.c b/grub-core/disk/efi/efidisk.c
+index 3b79f7bbc..a1a52a0a8 100644
+--- a/grub-core/disk/efi/efidisk.c
++++ b/grub-core/disk/efi/efidisk.c
+@@ -215,7 +215,7 @@ name_devices (struct grub_efidisk_data *devices)
+ 	    {
+ 	    case GRUB_EFI_HARD_DRIVE_DEVICE_PATH_SUBTYPE:
+ 	      is_hard_drive = 1;
+-	      /* Fall through by intention.  */
++	      /* Intentionally fall through.  */
+ 	    case GRUB_EFI_CDROM_DEVICE_PATH_SUBTYPE:
+ 	      {
+ 		struct grub_efidisk_data *parent, *parent2;
+diff --git a/grub-core/efiemu/mm.c b/grub-core/efiemu/mm.c
+index e606dbffc..52a032f7b 100644
+--- a/grub-core/efiemu/mm.c
++++ b/grub-core/efiemu/mm.c
+@@ -417,6 +417,7 @@ fill_hook (grub_uint64_t addr, grub_uint64_t size, grub_memory_type_t type,
+       default:
+ 	grub_dprintf ("efiemu",
+ 		      "Unknown memory type %d. Assuming unusable\n", type);
++	/* FALLTHROUGH */
+       case GRUB_MEMORY_RESERVED:
+ 	return grub_efiemu_add_to_mmap (addr, size,
+ 					GRUB_EFI_UNUSABLE_MEMORY);
+diff --git a/grub-core/gdb/cstub.c b/grub-core/gdb/cstub.c
+index c94411b10..b64acd70f 100644
+--- a/grub-core/gdb/cstub.c
++++ b/grub-core/gdb/cstub.c
+@@ -336,6 +336,7 @@ grub_gdb_trap (int trap_no)
+ 	/* sAA..AA: Step one instruction from AA..AA(optional).  */
+ 	case 's':
+ 	  stepping = 1;
++	  /* FALLTHROUGH */
+ 
+ 	/* cAA..AA: Continue at address AA..AA(optional).  */
+ 	case 'c':
+diff --git a/grub-core/gnulib/regexec.c b/grub-core/gnulib/regexec.c
+index f632cd47b..a7776f088 100644
+--- a/grub-core/gnulib/regexec.c
++++ b/grub-core/gnulib/regexec.c
+@@ -4099,6 +4099,9 @@ check_node_accept (const re_match_context_t *mctx, const re_token_t *node,
+     case OP_UTF8_PERIOD:
+       if (ch >= ASCII_CHARS)
+         return false;
++#if defined __GNUC__ && __GNUC__ >= 7
++      __attribute__ ((fallthrough));
++#endif
+       /* FALLTHROUGH */
+ #endif
+     case OP_PERIOD:
+diff --git a/grub-core/lib/xzembed/xz_dec_lzma2.c b/grub-core/lib/xzembed/xz_dec_lzma2.c
+index 8a2a1183d..af7b77079 100644
+--- a/grub-core/lib/xzembed/xz_dec_lzma2.c
++++ b/grub-core/lib/xzembed/xz_dec_lzma2.c
+@@ -1044,6 +1044,8 @@ enum xz_ret xz_dec_lzma2_run(
+ 
+ 			s->lzma2.sequence = SEQ_LZMA_PREPARE;
+ 
++		/* Fall through */
++
+ 		case SEQ_LZMA_PREPARE:
+ 			if (s->lzma2.compressed < RC_INIT_BYTES)
+ 				return XZ_DATA_ERROR;
+@@ -1054,6 +1056,8 @@ enum xz_ret xz_dec_lzma2_run(
+ 			s->lzma2.compressed -= RC_INIT_BYTES;
+ 			s->lzma2.sequence = SEQ_LZMA_RUN;
+ 
++		/* Fall through */
++
+ 		case SEQ_LZMA_RUN:
+ 			/*
+ 			 * Set dictionary limit to indicate how much we want
+diff --git a/grub-core/lib/xzembed/xz_dec_stream.c b/grub-core/lib/xzembed/xz_dec_stream.c
+index c16b13060..a29751e14 100644
+--- a/grub-core/lib/xzembed/xz_dec_stream.c
++++ b/grub-core/lib/xzembed/xz_dec_stream.c
+@@ -750,6 +750,7 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
+ 
+ 			s->sequence = SEQ_BLOCK_START;
+ 
++			/* FALLTHROUGH */
+ 		case SEQ_BLOCK_START:
+ 			/* We need one byte of input to continue. */
+ 			if (b->in_pos == b->in_size)
+@@ -773,6 +774,7 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
+ 			s->temp.pos = 0;
+ 			s->sequence = SEQ_BLOCK_HEADER;
+ 
++			/* FALLTHROUGH */
+ 		case SEQ_BLOCK_HEADER:
+ 			if (!fill_temp(s, b))
+ 				return XZ_OK;
+@@ -783,6 +785,7 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
+ 
+ 			s->sequence = SEQ_BLOCK_UNCOMPRESS;
+ 
++			/* FALLTHROUGH */
+ 		case SEQ_BLOCK_UNCOMPRESS:
+ 			ret = dec_block(s, b);
+ 			if (ret != XZ_STREAM_END)
+@@ -810,6 +813,7 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
+ 
+ 			s->sequence = SEQ_BLOCK_CHECK;
+ 
++			/* FALLTHROUGH */
+ 		case SEQ_BLOCK_CHECK:
+ 			ret = hash_validate(s, b, 0);
+ 			if (ret != XZ_STREAM_END)
+@@ -858,6 +862,7 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
+ 
+ 			s->sequence = SEQ_INDEX_CRC32;
+ 
++			/* FALLTHROUGH */
+ 		case SEQ_INDEX_CRC32:
+ 			ret = hash_validate(s, b, 1);
+ 			if (ret != XZ_STREAM_END)
+@@ -866,6 +871,7 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
+ 			s->temp.size = STREAM_HEADER_SIZE;
+ 			s->sequence = SEQ_STREAM_FOOTER;
+ 
++			/* FALLTHROUGH */
+ 		case SEQ_STREAM_FOOTER:
+ 			if (!fill_temp(s, b))
+ 				return XZ_OK;
+diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
+index fddcc461d..284603356 100644
+--- a/grub-core/loader/i386/linux.c
++++ b/grub-core/loader/i386/linux.c
+@@ -984,10 +984,13 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
+ 	      {
+ 	      case 'g':
+ 		shift += 10;
++		/* FALLTHROUGH */
+ 	      case 'm':
+ 		shift += 10;
++		/* FALLTHROUGH */
+ 	      case 'k':
+ 		shift += 10;
++		/* FALLTHROUGH */
+ 	      default:
+ 		break;
+ 	      }
+diff --git a/grub-core/tests/setjmp_test.c b/grub-core/tests/setjmp_test.c
+index 390cb26eb..604a6ce8f 100644
+--- a/grub-core/tests/setjmp_test.c
++++ b/grub-core/tests/setjmp_test.c
+@@ -25,7 +25,10 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ static grub_jmp_buf jmp_point;
+ static int expected, ctr;
+ 
+-#pragma GCC diagnostic ignored "-Wmissing-noreturn"
++/* This fixes GCC7 "unintentional fallthrough" warning */
++static void jmp0 (void) __attribute__ ((noreturn));
++static void jmp1 (void) __attribute__ ((noreturn));
++static void jmp2 (void) __attribute__ ((noreturn));
+ 
+ static void
+ jmp0 (void)
+diff --git a/grub-core/video/ieee1275.c b/grub-core/video/ieee1275.c
+index 0b150ec24..17a3dbbb5 100644
+--- a/grub-core/video/ieee1275.c
++++ b/grub-core/video/ieee1275.c
+@@ -181,6 +181,7 @@ grub_video_ieee1275_fill_mode_info (grub_ieee1275_phandle_t dev,
+     case 32:
+       out->reserved_mask_size = 8;
+       out->reserved_field_pos = 24;
++      /* FALLTHROUGH */
+ 
+     case 24:
+       out->red_mask_size = 8;
+diff --git a/grub-core/video/readers/jpeg.c b/grub-core/video/readers/jpeg.c
+index c3e0df240..21b0d9ded 100644
+--- a/grub-core/video/readers/jpeg.c
++++ b/grub-core/video/readers/jpeg.c
+@@ -736,6 +736,7 @@ grub_jpeg_decode_jpeg (struct grub_jpeg_data *data)
+ 	case JPEG_MARKER_SOS:	/* Start Of Scan.  */
+ 	  if (grub_jpeg_decode_sos (data))
+ 	    break;
++	  /* FALLTHROUGH */
+ 	case JPEG_MARKER_RST0:	/* Restart.  */
+ 	case JPEG_MARKER_RST1:
+ 	case JPEG_MARKER_RST2:
+diff --git a/util/getroot.c b/util/getroot.c
+index 92c0d709b..847406fba 100644
+--- a/util/getroot.c
++++ b/util/getroot.c
+@@ -99,7 +99,7 @@ grub_util_pull_device (const char *os_dev)
+     {
+     case GRUB_DEV_ABSTRACTION_LVM:
+       grub_util_pull_lvm_by_command (os_dev);
+-      /* Fallthrough in case that lvm-tools are unavailable.  */
++      /* Fallthrough - in case that lvm-tools are unavailable.  */
+     case GRUB_DEV_ABSTRACTION_LUKS:
+       grub_util_pull_devmapper (os_dev);
+       return;
+diff --git a/util/grub-install.c b/util/grub-install.c
+index 6c89c2b0c..9074d3e9e 100644
+--- a/util/grub-install.c
++++ b/util/grub-install.c
+@@ -1851,6 +1851,7 @@ main (int argc, char *argv[])
+ 	  free (mach_kernel);
+ 	  break;
+ 	}
++      /* FALLTHROUGH */
+     case GRUB_INSTALL_PLATFORM_ARM_EFI:
+     case GRUB_INSTALL_PLATFORM_ARM64_EFI:
+     case GRUB_INSTALL_PLATFORM_IA64_EFI:
+diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
+index 353a9407a..95ceab629 100644
+--- a/util/grub-mkimagexx.c
++++ b/util/grub-mkimagexx.c
+@@ -908,6 +908,7 @@ SUFFIX (relocate_addresses) (Elf_Ehdr *e, Elf_Shdr *sections,
+ 									    + sym->st_value
+ 									    - image_target->vaddr_offset));
+ 		  }
++		/* FALLTHROUGH */
+ 		case R_IA64_LTOFF_FPTR22:
+ 		  *gpptr = grub_host_to_target64 (addend + sym_addr);
+ 		  grub_ia64_add_value_to_slot_21 ((grub_addr_t) target,
+diff --git a/util/grub-mount.c b/util/grub-mount.c
+index aca5f82e3..a25db8a71 100644
+--- a/util/grub-mount.c
++++ b/util/grub-mount.c
+@@ -530,6 +530,7 @@ argp_parser (int key, char *arg, struct argp_state *state)
+       if (arg[0] != '-')
+ 	break;
+ 
++    /* FALLTHROUGH */
+     default:
+       if (!arg)
+ 	return 0;
+-- 
+2.13.2
+

--- a/recipes-bsp/grub/grub_git.bb
+++ b/recipes-bsp/grub/grub_git.bb
@@ -1,6 +1,5 @@
 require recipes-bsp/grub/grub2.inc
 
-DEPENDS += "autogen-native"
 DEPENDS_class-target = "grub-native"
 
 DEFAULT_PREFERENCE = "-1"
@@ -11,12 +10,14 @@ FILESEXTRAPATHS =. "${FILE_DIRNAME}/grub-git:"
 PV = "2.01+${SRCPV}"
 SRCREV = "b524fa27f56381bb0efa4944e36f50265113aee5"
 SRC_URI = "git://git.savannah.gnu.org/grub.git \
+           file://cfg.emmc \
+           file://cfg.sdcard \
            file://autogen.sh-exclude-pc.patch \
            file://0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch \
            file://0001-configure-add-check-for-no-pie-if-the-compiler-defau.patch \
-           file://cfg.emmc \
-           file://cfg.sdcard \
-"
+           file://0001-btrfs-avoid-used-uninitialized-error-with-GCC7.patch \
+           file://0002-i386-x86_64-ppc-fix-switch-fallthrough-cases-with-GC.patch \
+           "
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/grub/grub_git.bb
+++ b/recipes-bsp/grub/grub_git.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://git.savannah.gnu.org/grub.git \
            file://0001-configure-add-check-for-no-pie-if-the-compiler-defau.patch \
            file://0001-btrfs-avoid-used-uninitialized-error-with-GCC7.patch \
            file://0002-i386-x86_64-ppc-fix-switch-fallthrough-cases-with-GC.patch \
+           file://0001-Enforce-no-pie-if-the-compiler-supports-it.patch \
            "
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/uefi/edk2_git.bb
+++ b/recipes-bsp/uefi/edk2_git.bb
@@ -25,6 +25,9 @@ SRC_URI = "git://github.com/tianocore/edk2.git;name=edk2 \
 
 S = "${WORKDIR}/git"
 
+COMPATIBLE_MACHINE_juno = "(.*)"
+COMPATIBLE_MACHINE = "(-)"
+
 export AARCH64_TOOLCHAIN = "GCC49"
 export EDK2_DIR = "${S}"
 
@@ -45,6 +48,7 @@ export LINKER = "${CC}"
 LDFLAGS = ""
 
 export UEFIMACHINE ?= "${MACHINE_ARCH}"
+
 OPTEE_OS_ARG ?= ""
 
 do_compile() {


### PR DESCRIPTION
if not specified by machine, use hello target
this makes sure that in a mutli-bsp env where
there are BSP layers who do not support edk2 are
able to inter work with meta-96boards

Signed-off-by: Khem Raj <raj.khem@gmail.com>