### PR TITLE
hikey960: add a workaround for corrupted ext4 and sparse images

### DIFF
--- a/conf/machine/hikey960.conf
+++ b/conf/machine/hikey960.conf
@@ -45,3 +45,6 @@ IMAGE_ROOTFS_ALIGNMENT = "4096"
 EXTRA_IMAGECMD_ext4 += " -L rootfs "
 
 EXTRA_IMAGEDEPENDS = "grub"
+
+# FIXME unless we set image rootfs extra space, the generated image is corrupted.
+IMAGE_ROOTFS_EXTRA_SPACE = "1048576"


### PR DESCRIPTION
For unknown reason, the ext4 image seems to be corrupted.

It looks like a regression which happened around March 14-16.
* build #49 was fine:
http://builds.96boards.org/snapshots/reference-platform/openembedded/morty/hikey960/rpb/49/
* build #51 was broken:
http://builds.96boards.org/snapshots/reference-platform/openembedded/morty/hikey960/rpb/51/

By setting explicitely IMAGE_ROOTFS_EXTRA_SPACE to 1G, we ensure the ext4 image
is big enough. Conversion to a sparse image will reduce its size as
appropriate.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>