### PR TITLE
piglit: work around errors on GBM and EGL

### DIFF
--- a/recipes-graphics/piglit/piglit/0001-workaround-undefine-PIGLIT_HAS_GBM_BO_MAP.patch
+++ b/recipes-graphics/piglit/piglit/0001-workaround-undefine-PIGLIT_HAS_GBM_BO_MAP.patch
@@ -1,0 +1,44 @@
+From 2122ad7e07043f9b29a4ec4fac1a43cc38e4a415 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Thu, 4 May 2017 00:57:39 -0500
+Subject: [PATCH 1/2] workaround: undefine PIGLIT_HAS_GBM_BO_MAP
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This workaround is needed for Hikey and
+mali450-userland r6p0_01rel0.
+
+It's safe to assume that any GBM version >= 12.1 will include
+a definition of gbm_bo_map() and gbm_bo_unmap. However, in
+the case of libMali and a few companions, said definition can
+be found in the header file but not in the library itself.
+This leads to errors like the following when building:
+  undefined reference to `gbm_bo_unmap'
+
+Simply undefining PIGLIT_HAS_GBM_BO_MAP let's Piglit build
+correctly and carry on doing Piglit stuff.
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 983f4a3..8140314 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -141,10 +141,6 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+ 	if(GBM_FOUND)
+ 		set(PIGLIT_HAS_GBM True)
+ 		add_definitions(-DPIGLIT_HAS_GBM)
+-		if (GBM_VERSION VERSION_EQUAL "12.1" OR GBM_VERSION VERSION_GREATER "12.1")
+-			set(PIGLIT_HAS_GBM_BO_MAP True)
+-			add_definitions(-DPIGLIT_HAS_GBM_BO_MAP)
+-		endif()
+ 	endif(GBM_FOUND)
+ 
+ 	pkg_check_modules(WAYLAND QUIET wayland-client wayland-egl)
+-- 
+1.9.1
+

--- a/recipes-graphics/piglit/piglit/0002-workaround-don-t-try-to-test-egl_mesa_platform_surfa.patch
+++ b/recipes-graphics/piglit/piglit/0002-workaround-don-t-try-to-test-egl_mesa_platform_surfa.patch
@@ -1,0 +1,37 @@
+From 928567be1373627362cc8bf3ed8cb59f375375fe Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Thu, 4 May 2017 01:28:52 -0500
+Subject: [PATCH 2/2] workaround: don't try to test
+ egl_mesa_platform_surfaceless
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Errors like the following:
+  undefined reference to `eglGetPlatformDisplay'
+ocurr because those symbols are nowhere to be found in
+libMali.so. Even though Mali defines a cousin of this
+symbol (eglGetPlatformDisplayEXT), and because this is a very
+specific test, it can be skipped altogether so that the build
+continues given these symbols are not even included.
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ tests/egl/spec/CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tests/egl/spec/CMakeLists.txt b/tests/egl/spec/CMakeLists.txt
+index 66d76db..efebf3b 100644
+--- a/tests/egl/spec/CMakeLists.txt
++++ b/tests/egl/spec/CMakeLists.txt
+@@ -7,7 +7,6 @@ add_subdirectory (egl_khr_get_all_proc_addresses)
+ add_subdirectory (egl_khr_gl_image)
+ add_subdirectory (egl_khr_fence_sync)
+ add_subdirectory (egl_khr_surfaceless_context)
+-add_subdirectory (egl_mesa_platform_surfaceless)
+ 
+ if (PIGLIT_HAS_X11)
+ 	add_subdirectory (egl_chromium_sync_control)
+-- 
+1.9.1
+

--- a/recipes-graphics/piglit/piglit_%.bbappend
+++ b/recipes-graphics/piglit/piglit_%.bbappend
@@ -1,0 +1,5 @@
+SRC_URI_append_hikey = " file://0001-workaround-undefine-PIGLIT_HAS_GBM_BO_MAP.patch \
+                        file://0002-workaround-don-t-try-to-test-egl_mesa_platform_surfa.patch \
+"
+DEPENDS_append_hikey = " virtual/egl"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
First patch is about Piglit assuming GBM includes gbm_bo_map()
and gbm_bo_unmap() because of GBM's major version (>= 12.1),
but this turns out not to be the case with our Mali binary.

Second patch regards the lack of eglGetPlatformDisplay (and
other related symbols), which do exist as their EXT counter-
parts in Mali (eglGetPlatformDisplayEXT, etc.). This failure
is about testing eglGetPlatformDisplay, so the patch removes
the test entirely.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>