### PR TITLE
Include the patch from jforissier  for support SDP

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -5,7 +5,7 @@ COMPATIBLE_MACHINE = "hikey"
 DEPENDS_append = " dosfstools-native mtools-native grub optee-os"
 
 SRCREV_edk2 = "06e4def583a56aebb67d11ab8f782220bbc5f621"
-SRCREV_atf = "4adfdd06f11deb2ab6a056a68ed6f22dcb99a791"
+SRCREV_atf = "fb1158a365e2bf5bba638cde950678fddf67fe60"
 SRCREV_openplatformpkg = "f70886cd45a12a0ce961752de55dc70a878f8a15"
 
 SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp \


### PR DESCRIPTION
hikey: configure 4 MB of secure DRAM for OP-TEE Secure Data Path