### PR TITLE
linux-hikey_git: update kernel branch name

### DIFF
--- a/recipes-kernel/linux/linux-hikey_git.bb
+++ b/recipes-kernel/linux/linux-hikey_git.bb
@@ -6,7 +6,7 @@ PV = "4.9+git${SRCPV}"
 SRCREV_kernel = "04ec80a78dbc970cf921abc02910d2148cec6dbb"
 SRCREV_FORMAT = "kernel"
 
-SRC_URI = "git://github.com/Linaro/rpk.git;protocol=https;branch=master;name=kernel \
+SRC_URI = "git://github.com/Linaro/rpk.git;protocol=https;branch=rpk-v4.9;name=kernel \
 "
 
 SRC_URI_append_hikey = " \


### PR DESCRIPTION
Commit 04ec80a78 mentioned in SRCREV_kernel is no longer accessible
from master, and is only present in rpk-v4.9 branch:
  $ git branch --contains 04ec80a78
    rpk-v4.9

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>