### PR TITLE
edk2-hikey960: add recipe to build UEFI for HiKey960

### DIFF
--- a/conf/machine/hikey960.conf
+++ b/conf/machine/hikey960.conf
@@ -22,6 +22,7 @@ KERNEL_DEVICETREE = "hisilicon/hi3660-hikey960.dtb"
 SERIAL_CONSOLE = "115200 ttyAMA6"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "\
+    edk2-hikey960 \
     grub \
 "
 
@@ -44,7 +45,7 @@ IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 EXTRA_IMAGECMD_ext4 += " -L rootfs "
 
-EXTRA_IMAGEDEPENDS = "grub"
+EXTRA_IMAGEDEPENDS = "edk2-hikey960 grub"
 
 # FIXME unless we set image rootfs extra space, the generated image is corrupted.
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"

--- a/recipes-bsp/uefi/edk2-hikey960/config
+++ b/recipes-bsp/uefi/edk2-hikey960/config
@@ -1,0 +1,3 @@
+sec_usb_xloader.img 0x00020000
+sec_uce_boot.img 0x6A908000
+l-loader.bin 0x1AC00000

--- a/recipes-bsp/uefi/edk2-hikey960/grub.cfg.in
+++ b/recipes-bsp/uefi/edk2-hikey960/grub.cfg.in
@@ -1,0 +1,12 @@
+set default="0"
+set timeout=1
+
+menuentry 'CE Reference Platform (HiKey960 @DISTRO)' {
+    linux /boot/@KERNEL_IMAGETYPE console=tty0 @CMDLINE
+    devicetree /boot/hi3660-hikey960.dtb
+}
+
+menuentry 'Fastboot' {
+    search.fs_label boot boot_part
+    chainloader ($boot_part)/EFI/BOOT/fastboot.efi
+}

--- a/recipes-bsp/uefi/edk2-hikey960_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey960_git.bb
@@ -1,0 +1,88 @@
+require edk2_git.bb
+
+COMPATIBLE_MACHINE = "hikey960"
+
+DEPENDS_append = " dosfstools-native mtools-native fakeroot-native grub"
+
+inherit deploy pythonnative
+
+SRCREV_edk2 = "7efa39f3631ca8a42cc17210fb293b850aecbf3f"
+SRCREV_atf = "645904c8106640c6f694ce12d26ef4cb4184e196"
+SRCREV_openplatformpkg = "0e34c233f9d61c5dafa300176b2b022745d30d37"
+SRCREV_uefitools = "9857704d962ed9dad02e7cee2f3de240d132c872"
+SRCREV_lloader = "2835202b47bf734e48c6c25cd35ffbeecb8aa141"
+SRCREV_toolsimageshikey960 = "5716ead2fbf063b1ff578de7d6004a100d2ff92d"
+
+SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=testing/hikey960_v2.5 \
+           git://github.com/96boards-hikey/arm-trusted-firmware.git;name=atf;branch=testing/hikey960_v1.1;destsuffix=git/atf \
+           git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=testing/hikey960_v1.3.4;destsuffix=git/OpenPlatformPkg \
+           git://github.com/96boards-hikey/uefi-tools.git;name=uefitools;branch=testing/hikey960_v1;destsuffix=git/uefi-tools \
+           git://github.com/96boards-hikey/l-loader.git;name=lloader;branch=testing/hikey960_v1.2;destsuffix=git/l-loader \
+           git://github.com/96boards-hikey/tools-images-hikey960.git;name=toolsimageshikey960;destsuffix=git/tools-images-hikey960 \
+           file://grub.cfg.in \
+           file://config \
+          "
+
+# /usr/lib/edk2/bl1.bin not shipped files. [installed-vs-shipped]
+INSANE_SKIP_${PN} += "installed-vs-shipped"
+
+# workaround EDK2 is confused by the long path used during the build
+# and truncate files name expected by VfrCompile
+do_patch[postfuncs] += "set_max_path"
+set_max_path () {
+    sed -i -e 's/^#define MAX_PATH.*/#define MAX_PATH 511/' ${S}/BaseTools/Source/C/VfrCompile/EfiVfr.h
+}
+
+do_compile_append() {
+    cd ${EDK2_DIR}/l-loader
+    ln -s ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin
+    ln -s ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/fip.bin
+    ln -s ${EDK2_DIR}/Build/HiKey960/RELEASE_${AARCH64_TOOLCHAIN}/FV/BL33_AP_UEFI.fd
+    PTABLE=aosp-32g SECTOR_SIZE=4096 SGDISK=./sgdisk bash -x generate_ptable.sh
+    python gen_loader_hikey960.py -o l-loader.bin --img_bl1=bl1.bin --img_ns_bl1u=BL33_AP_UEFI.fd
+}
+
+do_install() {
+    install -D -p -m0644 ${EDK2_DIR}/Build/HiKey960/RELEASE_${AARCH64_TOOLCHAIN}/AARCH64/AndroidFastbootApp.efi ${D}/boot/EFI/BOOT/fastboot.efi
+    install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${D}${libdir}/edk2/bl1.bin
+
+    # Install grub configuration
+    sed -e "s|@DISTRO|${DISTRO}|" \
+        -e "s|@KERNEL_IMAGETYPE|${KERNEL_IMAGETYPE}|" \
+        -e "s|@CMDLINE|${CMDLINE}|" \
+        < ${WORKDIR}/grub.cfg.in \
+        > ${WORKDIR}/grub.cfg
+    install -D -p -m0644 ${WORKDIR}/grub.cfg ${D}/boot/grub/grub.cfg
+}
+
+# Create a 64M boot image. block size is 1024. (64*1024=65536)
+BOOT_IMAGE_SIZE = "65536"
+BOOT_IMAGE_BASE_NAME = "boot-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
+BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+
+# HiKey960 boot image requires fastboot and grub EFI
+# ensure we deploy grubaa64.efi before we try to create the boot image.
+do_deploy[depends] += "grub:do_deploy"
+do_deploy_append() {
+    mkdir -p ${DEPLOYDIR}/bootloader
+
+    cd ${EDK2_DIR}/l-loader
+    cp -a l-loader.bin prm_ptable.img ${DEPLOYDIR}/bootloader/
+    cd ${EDK2_DIR}/tools-images-hikey960
+    cp -a hikey_idt sec_uce_boot.img sec_usb_xloader.img sec_xloader.img ${DEPLOYDIR}/bootloader/
+    cp -a ${WORKDIR}/config ${DEPLOYDIR}/bootloader/
+
+    # Create boot image
+    mkfs.vfat -F32 -n "boot" -C ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${BOOT_IMAGE_SIZE}
+    mmd -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI
+    mmd -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ::EFI/BOOT
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${EDK2_DIR}/Build/HiKey960/RELEASE_${AARCH64_TOOLCHAIN}/AARCH64/AndroidFastbootApp.efi ::EFI/BOOT/fastboot.efi
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${DEPLOY_DIR_IMAGE}/grubaa64.efi ::EFI/BOOT/grubaa64.efi
+    chmod 644 ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img
+
+    (cd ${DEPLOYDIR} && ln -sf ${BOOT_IMAGE_BASE_NAME}.uefi.img boot-${MACHINE}.uefi.img)
+
+    # Fix up - move bootloader related files into a subdir
+    mv ${DEPLOYDIR}/fip.bin ${DEPLOYDIR}/bootloader/
+    rm -f ${DEPLOY_DIR_IMAGE}/grubaa64.efi
+}

--- a/recipes-bsp/uefi/edk2-hikey960_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey960_git.bb
@@ -7,8 +7,8 @@ DEPENDS_append = " dosfstools-native mtools-native fakeroot-native grub"
 inherit deploy pythonnative
 
 SRCREV_edk2 = "7efa39f3631ca8a42cc17210fb293b850aecbf3f"
-SRCREV_atf = "645904c8106640c6f694ce12d26ef4cb4184e196"
-SRCREV_openplatformpkg = "0e34c233f9d61c5dafa300176b2b022745d30d37"
+SRCREV_atf = "58c95367b955b8c1f29962c72dd4e5ea23c74776"
+SRCREV_openplatformpkg = "5960fa698ccb61a7a131b8be18c37a355044d88b"
 SRCREV_uefitools = "9857704d962ed9dad02e7cee2f3de240d132c872"
 SRCREV_lloader = "2835202b47bf734e48c6c25cd35ffbeecb8aa141"
 SRCREV_toolsimageshikey960 = "5716ead2fbf063b1ff578de7d6004a100d2ff92d"

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -7,10 +7,12 @@ DEPENDS_append = " dosfstools-native mtools-native grub optee-os"
 SRCREV_edk2 = "06e4def583a56aebb67d11ab8f782220bbc5f621"
 SRCREV_atf = "4adfdd06f11deb2ab6a056a68ed6f22dcb99a791"
 SRCREV_openplatformpkg = "f70886cd45a12a0ce961752de55dc70a878f8a15"
+SRCREV_uefitools = "12e8e46a138bd8e3b99a5ac7b1a7922f06500743"
 
 SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp \
            git://github.com/96boards-hikey/arm-trusted-firmware.git;name=atf;branch=hikey;destsuffix=git/atf \
            git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=hikey-aosp;destsuffix=git/OpenPlatformPkg \
+           git://git.linaro.org/uefi/uefi-tools.git;name=uefitools;destsuffix=git/uefi-tools \
            file://grub.cfg.in \
           "
 

--- a/recipes-bsp/uefi/edk2_git.bb
+++ b/recipes-bsp/uefi/edk2_git.bb
@@ -20,10 +20,8 @@ SRCREV_uefitools = "12e8e46a138bd8e3b99a5ac7b1a7922f06500743"
 SRC_URI = "git://github.com/tianocore/edk2.git;name=edk2 \
            git://github.com/ARM-software/arm-trusted-firmware.git;name=atf;destsuffix=git/atf \
            git://git.linaro.org/uefi/OpenPlatformPkg.git;name=openplatformpkg;destsuffix=git/OpenPlatformPkg \
+           git://git.linaro.org/uefi/uefi-tools.git;name=uefitools;destsuffix=git/uefi-tools \
           "
-
-SRC_URI_append = " git://git.linaro.org/uefi/uefi-tools.git;name=uefitools;destsuffix=git/uefi-tools \
-                 "
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Until it's upstreamed, we need to use a fork of UEFI tools which include
HiKey960 platform configuration. As a result, adjust other EDK2 recipes so
we can override UEFI tools in the board specific recipe.

For HiKey960, we don't use a separate recipe for l-loader. It's built as
part of the edk2 recipe and doesn't depends on an aarch32 toolchain

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>