### PR TITLE
edk2-hikey: bump ATF SRCREV

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -5,7 +5,7 @@ COMPATIBLE_MACHINE = "hikey"
 DEPENDS_append = " dosfstools-native mtools-native grub optee-os"
 
 SRCREV_edk2 = "06e4def583a56aebb67d11ab8f782220bbc5f621"
-SRCREV_atf = "4adfdd06f11deb2ab6a056a68ed6f22dcb99a791"
+SRCREV_atf = "fb1158a365e2bf5bba638cde950678fddf67fe60"
 SRCREV_openplatformpkg = "f70886cd45a12a0ce961752de55dc70a878f8a15"
 
 SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp \


### PR DESCRIPTION
Bump ATF SRCREV to include Jerome Forissier patch for HiKey SDP support:
Configure 4 MB of secure DRAM for OP-TEE Secure Data Path

Update the memory firewall configuration to reserve 4 MB of secure RAM
for use by the kernel and OP-TEE as the Secure Data Path pool.
Note that this address range (0x3E800000 - 0x3EC00000) falls in the
range already set aside by UEFI (which reserves the upper 32 MB of the
1GB DRAM for OP-TEE [1]) and was previously unused.

[1] https://github.com/96boards-hikey/edk2/blob/hikey/HisiPkg/HiKeyPkg/Library/HiKeyLib/HiKeyMem.c#L44

Signed-off-by: jennifermu111 <jie.mu@linaro.org>