### PR TITLE
96boards Poplar OE board support

### DIFF
--- a/conf/machine/poplar.conf
+++ b/conf/machine/poplar.conf
@@ -1,0 +1,40 @@
+#@TYPE: Machine
+#@NAME: ToCoding Poplar machine
+#@DESCRIPTION: ToCoding Poplar machine
+
+require conf/machine/include/arm/arch-armv8.inc
+
+PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
+
+XSERVER ?= "xserver-xorg \
+            mesa-driver-swrast \
+            xf86-input-evdev \
+            xf86-video-fbdev \
+           "
+
+MACHINE_FEATURES = "usbhost usbgadget alsa screen ext2"
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-poplar"
+
+KERNEL_IMAGETYPE = "Image"
+KERNEL_DEVICETREE = "hisilicon/hi3798cv200-poplar.dtb"
+
+UBOOT_MACHINE = "poplar_defconfig"
+
+SERIAL_CONSOLES = "115200;ttyAMA0"
+
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "\
+    atf-poplar \
+    l-loader-poplar \
+    u-boot-poplar \
+"
+
+CMDLINE_ROOT_EMMC   ?= "mmcblk0p3"
+CMDLINE ?= "console=ttyAMA0,115200n8 root=/dev/${CMDLINE_ROOT_EMMC} rootwait rw quiet"
+
+# Fastboot expects an ext4 image, which needs to be 4096 bytes aligned
+IMAGE_FSTYPES_append = " ext4.gz"
+IMAGE_ROOTFS_ALIGNMENT = "4096"
+EXTRA_IMAGECMD_ext4 += " -L rootfs "
+
+EXTRA_IMAGEDEPENDS = "atf-poplar l-loader-poplar u-boot-poplar"

--- a/recipes-bsp/atf/atf-poplar_git.bb
+++ b/recipes-bsp/atf/atf-poplar_git.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "ARM Trusted Firmware Poplar"
+
+LICENSE="BSD"
+LIC_FILES_CHKSUM = "file://license.md;md5=829bdeb34c1d9044f393d5a16c068371"
+
+COMPATIBLE_MACHINE = "poplar"
+
+DEPENDS = " u-boot-poplar openssl-native"
+
+SRCREV = "dc20ebf4faf350567f537e204453497666bd6f6d"
+
+SRC_URI = "git://github.com/linaro/poplar-arm-trusted-firmware.git;name=atf;branch=latest;"
+
+S = "${WORKDIR}/git"
+
+# /usr/lib/atf/bl1.bin not shipped files. [installed-vs-shipped]
+INSANE_SKIP_${PN} += "installed-vs-shipped"
+
+export LDFLAGS=""
+
+do_compile() {
+
+    oe_runmake CROSS_COMPILE=${TARGET_PREFIX} all fip DEBUG=1 PLAT=${COMPATIBLE_MACHINE} SPD=none \
+		       BL33=${DEPLOY_DIR_IMAGE}/u-boot.bin
+}
+
+do_install() {
+    install -D -p -m0644 ${S}/build/${COMPATIBLE_MACHINE}/debug/bl1.bin ${D}${libdir}/atf/bl1.bin
+    install -D -p -m0644 ${S}/build/${COMPATIBLE_MACHINE}/debug/fip.bin ${D}${libdir}/atf/fip.bin
+}
+
+FILES_${PN} += "${libdir}/atf/*"
+

--- a/recipes-bsp/l-loader/l-loader-poplar_git.bb
+++ b/recipes-bsp/l-loader/l-loader-poplar_git.bb
@@ -1,0 +1,53 @@
+SUMMARY = "Loader to switch from aarch32 to aarch64 and boot"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=e8c1458438ead3c34974bc0be3a03ed6"
+
+COMPATIBLE_MACHINE = "poplar"
+DEPENDS += " atf-poplar coreutils-native util-linux-native"
+
+inherit deploy pythonnative
+
+SRCREV = "c9bccc57ddef1baa8f7adb8618c7f8a5b71ad4cc"
+
+### DISCLAIMER ###
+# l-loader should be built with an aarch32 toolchain but we target an
+# ARMv8 machine. OE cross-toolchain is aarch64 in this case.
+# We decided to use an external pre-built toolchain in order to build
+# l-loader.
+# knowledgeably, it is a hack...
+###
+SRC_URI = "git://github.com/Linaro/poplar-l-loader.git;branch=latest \
+           http://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/arm-linux-gnueabihf/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf.tar.xz;name=tc \
+"
+SRC_URI[tc.md5sum] = "01d8860d62807b676762c9c2576dfb22"
+SRC_URI[tc.sha256sum] = "dd66f07662e1f3b555eaa0d076f133b6db702ab0b9ab18f7dfc91a23eab653c5"
+
+S = "${WORKDIR}/git"
+
+do_configure[noexec] = "1"
+
+do_compile() {
+    # Use pre-built aarch32 toolchain
+    export PATH=${WORKDIR}/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf/bin:$PATH
+
+    # bl1 from fip.bin are required from ATF
+    rm -f atf/bl1.bin
+    rm -f arf/fip.bin
+    ln -sf ${STAGING_LIBDIR}/atf/bl1.bin ${S}/atf/bl1.bin
+    ln -sf ${STAGING_LIBDIR}/atf/fip.bin ${S}/atf/fip.bin
+
+    make
+}
+
+do_install() {
+    install -D -p -m0644 fastboot.bin ${D}${libdir}/l-loader/fastboot.bin
+}
+
+do_deploy() {
+    install -D -p -m0644 fastboot.bin ${DEPLOYDIR}/fastboot.bin
+}
+
+FILES_${PN} += "${libdir}/l-loader"
+
+addtask deploy before do_build after do_compile

--- a/recipes-bsp/u-boot/u-boot-poplar.bb
+++ b/recipes-bsp/u-boot/u-boot-poplar.bb
@@ -1,0 +1,28 @@
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
+
+SUMMARY = "U-Boot bootloader for HiSilicon Poplar"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+
+SRC_URI = "git://github.com/linaro/poplar-u-boot;protocol=git;branch=latest"
+SRCREV = "15a3c4c05689b7681ce9899c91861bbbdc06eb84"
+
+PV = "v2017.05+git${SRCPV}"
+
+# u-boot needs devtree compiler to parse dts files
+DEPENDS += "dtc-native bc-native"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+S = "${WORKDIR}/git"
+
+UBOOT_EXTLINUX ??= "1"
+UBOOT_EXTLINUX_LABELS ??= "default"
+UBOOT_EXTLINUX_KERNEL_IMAGE_default ??= "../Image"
+UBOOT_EXTLINUX_MENU_DESCRIPTION_default ??= "Linux Default"
+UBOOT_EXTLINUX_FDTDIR ??= "../"
+UBOOT_EXTLINUX_KERNEL_ARGS ??= "append mem=1G earlycon console=ttyAMA0"
+UBOOT_EXTLINUX_ROOT ??= "root=/dev/mmcblk0p3 rootfstype=ext4 rootwait rw"

--- a/recipes-kernel/linux/linux-poplar_git.bb
+++ b/recipes-kernel/linux/linux-poplar_git.bb
@@ -1,0 +1,78 @@
+require linux.inc
+
+DESCRIPTION = "96boards-poplar kernel"
+
+DEPENDS_append = " dosfstools-native mtools-native u-boot-poplar"
+
+PV = "4.9+git${SRCPV}"
+SRCREV = "035bdfc09e5c57d85e5b72ac04a588426e44f728"
+SRC_URI = "git://github.com/Linaro/poplar-linux.git;protocol=https;branch=latest;name=kernel \
+"
+
+S = "${WORKDIR}/git"
+
+COMPATIBLE_MACHINE = "poplar"
+KERNEL_IMAGETYPE ?= "Image"
+
+# make[3]: *** [scripts/extract-cert] Error 1
+DEPENDS += "openssl-native"
+HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
+
+do_configure() {
+    # Make sure to disable debug info and enable ext4fs built-in
+    sed -e '/CONFIG_EXT4_FS=/d' \
+        -e '/CONFIG_DEBUG_INFO=/d' \
+        < ${S}/arch/arm64/configs/defconfig \
+        > ${B}/.config
+
+    echo 'CONFIG_EXT4_FS=y' >> ${B}/.config
+    echo '# CONFIG_DEBUG_INFO is not set' >> ${B}/.config
+
+    # Check for kernel config fragments. The assumption is that the config
+    # fragment will be specified with the absolute path. For example:
+    #   * ${WORKDIR}/config1.cfg
+    #   * ${S}/config2.cfg
+    # Iterate through the list of configs and make sure that you can find
+    # each one. If not then error out.
+    # NOTE: If you want to override a configuration that is kept in the kernel
+    #       with one from the OE meta data then you should make sure that the
+    #       OE meta data version (i.e. ${WORKDIR}/config1.cfg) is listed
+    #       after the in-kernel configuration fragment.
+    # Check if any config fragments are specified.
+    if [ ! -z "${KERNEL_CONFIG_FRAGMENTS}" ]; then
+        for f in ${KERNEL_CONFIG_FRAGMENTS}; do
+            # Check if the config fragment was copied into the WORKDIR from
+            # the OE meta data
+            if [ ! -e "$f" ]; then
+                echo "Could not find kernel config fragment $f"
+                exit 1
+            fi
+        done
+
+        # Now that all the fragments are located merge them.
+        ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
+    fi
+
+    yes '' | oe_runmake -C ${S} O=${B} oldconfig
+
+    bbplain "Saving defconfig to:\n${B}/defconfig"
+    oe_runmake -C ${B} savedefconfig
+    cp -a ${B}/defconfig ${DEPLOYDIR}
+}
+
+# Create a 128M boot image. block size is 1024. (128*1024=131072)
+BOOT_IMAGE_SIZE = "131072"
+BOOT_IMAGE_BASE_NAME = "boot-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
+BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+
+do_deploy_append() {
+    # Create boot image
+    mkfs.vfat -F32 -n "boot" -C ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img ${BOOT_IMAGE_SIZE}
+
+    mmd -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img ::extlinux
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${KERNEL_IMAGETYPE} ::${KERNEL_IMAGETYPE}
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/Image-hi3798cv200-poplar.dtb ::hi3798cv200-poplar.dtb
+    mcopy -i ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img ${DEPLOY_DIR_IMAGE}/extlinux.conf ::extlinux/extlinux.conf
+
+    (cd ${DEPLOYDIR} && ln -sf ${BOOT_IMAGE_BASE_NAME}.img boot-${MACHINE}.img)
+}


### PR DESCRIPTION
Hi folks,

This pull request adds Poplar OE recipes for l-loader-poplar, ATF, U-Boot, and Linux. Currently this code is being pulled from Linaro GitHub but once various parts get upstreamed we should be able to switch to upstream repos. 

This has been tested with rpb-console-image, and the resulting binaries once flashed onto the board, boot correctly and mount the rootfs.

Build artifacts are: -
fastboot.bin (contains mbr, l-loader, atf & u-boot): Once this is flashed board will boot into U-Boot on next reboot. mbr is being generated in l-loader-poplar repo via a script similar to hikey).

boot-poplar.img: fat boot image containing kernel, dtb and extlinux.conf

rpb-console-image-poplar.ext4 (rootfs)

Installation
=========

Copy build artifacts onto a USB stick, and then hold USB boot button and turn on board. Board will boot into U-Boot from fastboot on USB stick.

Flashing
======

At U-boot prompt:

fatload usb 0:1 0x08000000 fastboot.bin
mmc write 0x08000000 0 0x780

fatload usb 0:1 0x08000000 boot-poplar.img
mmc write 0x08000000 0x2000 0x40000

fatload usb 0:1 0x08000000 rpb-console-image-poplar.ext4
mmc write 0x08000000 0x46800 <size of image in bytes divided by 512>

Reboot board. See boot log below

===

Bootrom start
Boot Media: eMMC
Decrypt auxiliary code ...OK

lsadc voltage min: 000000FF, max: 000000FF, aver: 000000FF, index: 00000000

Entry boot auxiliary code

Auxiliary code - v1.00
DDR code - V1.1.2 20160205
Build: Mar 24 2016 - 17:09:44

Reg Version:  v134
Reg Time:     2016/03/18 09:44:55
Reg Name:     hi3798cv2dmb_hi3798cv200_ddr3_2gbyte_8bitx4_4layers.reg

Boot auxiliary code success
Bootrom success

LOADER:  Switched to aarch64 mode
LOADER:  Entering ARM TRUSTED FIRMWARE
LOADER:  CPU0 executes at 0x000ce000

INFO:    BL1: 0xe1000 - 0xe7000 [size = 24576]
NOTICE:  Booting Trusted Firmware
NOTICE:  BL1: v1.3(debug):dc20ebf
NOTICE:  BL1: Built : 19:38:45, Jun  6 2017
INFO:    BL1: RAM 0xe1000 - 0xe7000
INFO:    BL1: cortex_a53: errata workaround for 855873 was applied
INFO:    BL1: Loading BL2
INFO:    Loading image id=1 at address 0xe9000
INFO:    Image id=1 loaded at address 0xe9000, size = 0x5008
NOTICE:  BL1: Booting BL2
INFO:    Entry point address = 0xe9000
INFO:    SPSR = 0x3c5
NOTICE:  BL2: v1.3(debug):dc20ebf
NOTICE:  BL2: Built : 19:38:45, Jun  6 2017
INFO:    BL2: Loading BL31
INFO:    Loading image id=3 at address 0x129000
INFO:    Image id=3 loaded at address 0x129000, size = 0x8020
INFO:    BL2: Loading BL33
INFO:    Loading image id=5 at address 0x37000000
INFO:    Image id=5 loaded at address 0x37000000, size = 0x56867
NOTICE:  BL1: Booting BL31
INFO:    Entry point address = 0x129000
INFO:    SPSR = 0x3cd
INFO:    Boot BL33 from 0x37000000 for 354407 Bytes
NOTICE:  BL31: v1.3(debug):dc20ebf
NOTICE:  BL31: Built : 19:38:45, Jun  6 2017
INFO:    ARM GICv2 driver initialized
INFO:    BL31: Initializing runtime services
INFO:    BL31: cortex_a53: errata workaround for 855873 was applied
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0x37000000
INFO:    SPSR = 0x3c9


U-Boot 2017.05 (Jun 06 2017 - 19:18:00 +0200)poplar

Model: HiSilicon Poplar Development Board
BOARD: Hisilicon HI3798cv200 Poplar
DRAM:  1024 MiB
MMC:   Hisilicon DWMMC: 0
In:    serial@8b00000
Out:   serial@8b00000
Err:   serial@8b00000
Net:   Net Initialization Skipped
No ethernet found.
Hit any key to stop autoboot:  0 
starting USB...
USB0:   USB EHCI 1.00
scanning bus 0 for devices... 2 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
       scanning usb for ethernet devices... 0 Ethernet Device(s) found

USB device 0: unknown device
switch to partitions #0, OK
mmc0(part 0) is current device
Scanning mmc 0:2...
Found /extlinux/extlinux.conf
Retrieving file: /extlinux/extlinux.conf
reading /extlinux/extlinux.conf
240 bytes read in 4 ms (58.6 KiB/s)
1:      Reference-Platform-Build-X11
Retrieving file: /extlinux/../Image
reading /extlinux/../Image
15798784 bytes read in 1393 ms (10.8 MiB/s)
append: root=/dev/mmcblk0p3 rootfstype=ext4 rootwait rw append mem=1G earlycon console=ttyAMA0 console=
Retrieving file: /extlinux/../hi3798cv200-poplar.dtb
reading /extlinux/../hi3798cv200-poplar.dtb
9197 bytes read in 7 ms (1.3 MiB/s)
## Flattened Device Tree blob at 32200000
   Booting using the fdt blob at 0x32200000
   Loading Device Tree to 0000000000123000, end 00000000001283ec ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 4.11.2-g035bdfc-dirty (oe-user@oe-host) (gcc version 6.3.1 20170109 (Linaro GCC 6.3-2017.02-rc3~dev) ) #1 SMP PREEMPT Tue Jun 6 19:26:14 CEST 2017
[    0.000000] Boot CPU: AArch64 Processor [410fd034]
[    0.000000] Memory limited to 1024MB
[    0.000000] efi: Getting EFI parameters from FDT:
[    0.000000] efi: UEFI not found.
[    0.000000] cma: Reserved 16 MiB at 0x000000003f000000
[    0.000000] earlycon: pl11 at MMIO 0x00000000f8b00000 (options '115200n8')
[    0.000000] bootconsole [pl11] enabled
[    0.000000] NUMA: No NUMA configuration found
[    0.000000] NUMA: Faking a node at [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000] NUMA: Adding memblock [0x0 - 0x128fff] on node 0
[    0.000000] NUMA: Adding memblock [0x132000 - 0x3fffffff] on node 0
[    0.000000] NUMA: Initmem setup node 0 [mem 0x00000000-0x3fffffff]
[    0.000000] NUMA: NODE_DATA [mem 0x3efe6200-0x3efe7cff]
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000000128fff]
[    0.000000]   node   0: [mem 0x0000000000132000-0x000000003fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.0 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] percpu: Embedded 23 pages/cpu @ffff80003ef87000 s56856 r8192 d29160 u94208
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: enabling workaround for ARM erratum 845719
[    0.000000] Built 1 zonelists in Node order, mobility grouping on.  Total pages: 258039
[    0.000000] Policy zone: DMA
[    0.000000] Kernel command line: root=/dev/mmcblk0p3 rootfstype=ext4 rootwait rw append mem=1G earlycon console=ttyAMA0 console=
[    0.000000] PID hash table entries: 4096 (order: 3, 32768 bytes)
[    0.000000] Memory: 999392K/1048540K available (9084K kernel code, 1028K rwdata, 4160K rodata, 1088K init, 407K bss, 32764K reserved, 16384K cma-reserved)
[    0.000000] Virtual kernel memory layout:
[    0.000000]     modules : 0xffff000000000000 - 0xffff000008000000   (   128 MB)
[    0.000000]     vmalloc : 0xffff000008000000 - 0xffff7dffbfff0000   (129022 GB)
[    0.000000]       .text : 0xffff000008080000 - 0xffff000008960000   (  9088 KB)
[    0.000000]     .rodata : 0xffff000008960000 - 0xffff000008d80000   (  4224 KB)
[    0.000000]       .init : 0xffff000008d80000 - 0xffff000008e90000   (  1088 KB)
[    0.000000]       .data : 0xffff000008e90000 - 0xffff000008f91200   (  1029 KB)
[    0.000000]        .bss : 0xffff000008f91200 - 0xffff000008ff6eac   (   408 KB)
[    0.000000]     fixed   : 0xffff7dfffe7fd000 - 0xffff7dfffec00000   (  4108 KB)
[    0.000000]     PCI I/O : 0xffff7dfffee00000 - 0xffff7dffffe00000   (    16 MB)
[    0.000000]     vmemmap : 0xffff7e0000000000 - 0xffff800000000000   (  2048 GB maximum)
[    0.000000]               0xffff7e0000000000 - 0xffff7e0001000000   (    16 MB actual)
[    0.000000]     memory  : 0xffff800000000000 - 0xffff800040000000   (  1024 MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] Preemptible hierarchical RCU implementation.
[    0.000000]  Build-time adjustment of leaf fanout to 64.
[    0.000000]  RCU restricting CPUs from NR_CPUS=64 to nr_cpu_ids=4.
[    0.000000] RCU: Adjusting geometry for rcu_fanout_leaf=64, nr_cpu_ids=4
[    0.000000] NR_IRQS:64 nr_irqs:64 0
[    0.000000] arm_arch_timer: Architected cp15 timer(s) running at 24.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x588fe9dc0, max_idle_ns: 440795202592 ns
[    0.000003] sched_clock: 56 bits at 24MHz, resolution 41ns, wraps every 4398046511097ns
[    0.008248] Console: colour dummy device 80x25
[    0.012768] Calibrating delay loop (skipped), value calculated using timer frequency.. 48.00 BogoMIPS (lpj=96000)
[    0.023150] pid_max: default: 32768 minimum: 301
[    0.027858] Security Framework initialized
[    0.032158] Dentry cache hash table entries: 131072 (order: 8, 1048576 bytes)
[    0.039944] Inode-cache hash table entries: 65536 (order: 7, 524288 bytes)
[    0.047150] Mount-cache hash table entries: 2048 (order: 2, 16384 bytes)
[    0.053928] Mountpoint-cache hash table entries: 2048 (order: 2, 16384 bytes)
[    0.077185] ASID allocator initialised with 65536 entries
[    0.090858] EFI services will not be available.
[    0.111460] smp: Bringing up secondary CPUs ...
[    0.148127] Detected VIPT I-cache on CPU1
[    0.148159] CPU1: Booted secondary processor [410fd034]
[    0.180148] Detected VIPT I-cache on CPU2
[    0.180165] CPU2: Booted secondary processor [410fd034]
[    0.212183] Detected VIPT I-cache on CPU3
[    0.212198] CPU3: Booted secondary processor [410fd034]
[    0.212228] smp: Brought up 1 node, 4 CPUs
[    0.244345] SMP: Total of 4 processors activated.
[    0.249099] CPU features: detected feature: 32-bit EL0 Support
[    0.255019] CPU: All CPU(s) started at EL2
[    0.259167] alternatives: patching kernel code
[    0.264209] devtmpfs: initialized
[    0.268787] DMI not present or invalid.
[    0.272767] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.282648] futex hash table entries: 1024 (order: 5, 131072 bytes)
[    0.289335] pinctrl core: initialized pinctrl subsystem
[    0.295347] NET: Registered protocol family 16
[    0.303893] cpuidle: using governor menu
[    0.308111] vdso: 2 pages (1 code @ ffff000008967000, 1 data @ ffff000008e95000)
[    0.315598] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
[    0.323121] DMA: preallocated 256 KiB pool for atomic allocations
[    0.329508] Serial: AMBA PL011 UART driver
[    0.334668] f8b00000.serial: ttyAMA0 at MMIO 0xf8b00000 (irq = 5, base_baud = 0) is a PL011 rev2
[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 4.11.2-g035bdfc-dirty (oe-user@oe-host) (gcc version 6.3.1 20170109 (Linaro GCC 6.3-2017.02-rc3~dev) ) #1 SMP PREEMPT Tue Jun 6 19:26:14 CEST 2017
[    0.000000] Boot CPU: AArch64 Processor [410fd034]
[    0.000000] Memory limited to 1024MB
[    0.000000] efi: Getting EFI parameters from FDT:
[    0.000000] efi: UEFI not found.
[    0.000000] cma: Reserved 16 MiB at 0x000000003f000000
[    0.000000] earlycon: pl11 at MMIO 0x00000000f8b00000 (options '115200n8')
[    0.000000] bootconsole [pl11] enabled
[    0.000000] NUMA: No NUMA configuration found
[    0.000000] NUMA: Faking a node at [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000] NUMA: Adding memblock [0x0 - 0x128fff] on node 0
[    0.000000] NUMA: Adding memblock [0x132000 - 0x3fffffff] on node 0
[    0.000000] NUMA: Initmem setup node 0 [mem 0x00000000-0x3fffffff]
[    0.000000] NUMA: NODE_DATA [mem 0x3efe6200-0x3efe7cff]
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000000128fff]
[    0.000000]   node   0: [mem 0x0000000000132000-0x000000003fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.0 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] percpu: Embedded 23 pages/cpu @ffff80003ef87000 s56856 r8192 d29160 u94208
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: enabling workaround for ARM erratum 845719
[    0.000000] Built 1 zonelists in Node order, mobility grouping on.  Total pages: 258039
[    0.000000] Policy zone: DMA
[    0.000000] Kernel command line: root=/dev/mmcblk0p3 rootfstype=ext4 rootwait rw append mem=1G earlycon console=ttyAMA0 console=
[    0.000000] PID hash table entries: 4096 (order: 3, 32768 bytes)
[    0.000000] Memory: 999392K/1048540K available (9084K kernel code, 1028K rwdata, 4160K rodata, 1088K init, 407K bss, 32764K reserved, 16384K cma-reserved)
[    0.000000] Virtual kernel memory layout:
[    0.000000]     modules : 0xffff000000000000 - 0xffff000008000000   (   128 MB)
[    0.000000]     vmalloc : 0xffff000008000000 - 0xffff7dffbfff0000   (129022 GB)
[    0.000000]       .text : 0xffff000008080000 - 0xffff000008960000   (  9088 KB)
[    0.000000]     .rodata : 0xffff000008960000 - 0xffff000008d80000   (  4224 KB)
[    0.000000]       .init : 0xffff000008d80000 - 0xffff000008e90000   (  1088 KB)
[    0.000000]       .data : 0xffff000008e90000 - 0xffff000008f91200   (  1029 KB)
[    0.000000]        .bss : 0xffff000008f91200 - 0xffff000008ff6eac   (   408 KB)
[    0.000000]     fixed   : 0xffff7dfffe7fd000 - 0xffff7dfffec00000   (  4108 KB)
[    0.000000]     PCI I/O : 0xffff7dfffee00000 - 0xffff7dffffe00000   (    16 MB)
[    0.000000]     vmemmap : 0xffff7e0000000000 - 0xffff800000000000   (  2048 GB maximum)
[    0.000000]               0xffff7e0000000000 - 0xffff7e0001000000   (    16 MB actual)
[    0.000000]     memory  : 0xffff800000000000 - 0xffff800040000000   (  1024 MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] Preemptible hierarchical RCU implementation.
[    0.000000]  Build-time adjustment of leaf fanout to 64.
[    0.000000]  RCU restricting CPUs from NR_CPUS=64 to nr_cpu_ids=4.
[    0.000000] RCU: Adjusting geometry for rcu_fanout_leaf=64, nr_cpu_ids=4
[    0.000000] NR_IRQS:64 nr_irqs:64 0
[    0.000000] arm_arch_timer: Architected cp15 timer(s) running at 24.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x588fe9dc0, max_idle_ns: 440795202592 ns
[    0.000003] sched_clock: 56 bits at 24MHz, resolution 41ns, wraps every 4398046511097ns
[    0.008248] Console: colour dummy device 80x25
[    0.012768] Calibrating delay loop (skipped), value calculated using timer frequency.. 48.00 BogoMIPS (lpj=96000)
[    0.023150] pid_max: default: 32768 minimum: 301
[    0.027858] Security Framework initialized
[    0.032158] Dentry cache hash table entries: 131072 (order: 8, 1048576 bytes)
[    0.039944] Inode-cache hash table entries: 65536 (order: 7, 524288 bytes)
[    0.047150] Mount-cache hash table entries: 2048 (order: 2, 16384 bytes)
[    0.053928] Mountpoint-cache hash table entries: 2048 (order: 2, 16384 bytes)
[    0.077185] ASID allocator initialised with 65536 entries
[    0.090858] EFI services will not be available.
[    0.111460] smp: Bringing up secondary CPUs ...
[    0.148127] Detected VIPT I-cache on CPU1
[    0.148159] CPU1: Booted secondary processor [410fd034]
[    0.180148] Detected VIPT I-cache on CPU2
[    0.180165] CPU2: Booted secondary processor [410fd034]
[    0.212183] Detected VIPT I-cache on CPU3
[    0.212198] CPU3: Booted secondary processor [410fd034]
[    0.212228] smp: Brought up 1 node, 4 CPUs
[    0.244345] SMP: Total of 4 processors activated.
[    0.249099] CPU features: detected feature: 32-bit EL0 Support
[    0.255019] CPU: All CPU(s) started at EL2
[    0.259167] alternatives: patching kernel code
[    0.264209] devtmpfs: initialized
[    0.268787] DMI not present or invalid.
[    0.272767] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.282648] futex hash table entries: 1024 (order: 5, 131072 bytes)
[    0.289335] pinctrl core: initialized pinctrl subsystem
[    0.295347] NET: Registered protocol family 16
[    0.303893] cpuidle: using governor menu
[    0.308111] vdso: 2 pages (1 code @ ffff000008967000, 1 data @ ffff000008e95000)
[    0.315598] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
[    0.323121] DMA: preallocated 256 KiB pool for atomic allocations
[    0.329508] Serial: AMBA PL011 UART driver
[    0.334668] f8b00000.serial: ttyAMA0 at MMIO 0xf8b00000 (irq = 5, base_baud = 0) is a PL011 rev2
[    0.887859] console [ttyAMA0] enabled
[    0.887859] console [ttyAMA0] enabled
[    0.895470] f8b02000.serial: ttyAMA2 at MMIO 0xf8b02000 (irq = 6, base_baud = 0) is a PL011 rev2
[    0.895470] f8b02000.serial: ttyAMA2 at MMIO 0xf8b02000 (irq = 6, base_baud = 0) is a PL011 rev2
[    0.913509] OF: amba_device_add() failed (-19) for /soc@f0000000/spi@8b1a000
[    0.913509] OF: amba_device_add() failed (-19) for /soc@f0000000/spi@8b1a000
[    0.928176] OF: amba_device_add() failed (-19) for /soc@f0000000/gpio@8004000
[    0.928176] OF: amba_device_add() failed (-19) for /soc@f0000000/gpio@8004000
[    0.949030] HugeTLB registered 2 MB page size, pre-allocated 0 pages
[    0.949030] HugeTLB registered 2 MB page size, pre-allocated 0 pages
[    0.962343] ACPI: Interpreter disabled.
[    0.962343] ACPI: Interpreter disabled.
[    0.970435] vgaarb: loaded
[    0.970435] vgaarb: loaded
[    0.976571] SCSI subsystem initialized
[    0.976571] SCSI subsystem initialized
[    0.984393] usbcore: registered new interface driver usbfs
[    0.984393] usbcore: registered new interface driver usbfs
[    0.995464] usbcore: registered new interface driver hub
[    0.995464] usbcore: registered new interface driver hub
[    1.006191] usbcore: registered new device driver usb
[    1.006191] usbcore: registered new device driver usb
[    1.016522] media: Linux media interface: v0.10
[    1.016522] media: Linux media interface: v0.10
[    1.025683] Linux video capture interface: v2.00
[    1.025683] Linux video capture interface: v2.00
[    1.035003] pps_core: LinuxPPS API ver. 1 registered
[    1.035003] pps_core: LinuxPPS API ver. 1 registered
[    1.044971] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
[    1.044971] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
[    1.063339] PTP clock support registered
[    1.063339] PTP clock support registered
[    1.071309] dmi: Firmware registration failed.
[    1.071309] dmi: Firmware registration failed.
[    1.080318] Advanced Linux Sound Architecture Driver Initialized.
[    1.080318] Advanced Linux Sound Architecture Driver Initialized.
[    1.093053] clocksource: Switched to clocksource arch_sys_counter
[    1.093053] clocksource: Switched to clocksource arch_sys_counter
[    1.105390] VFS: Disk quotas dquot_6.6.0
[    1.105390] VFS: Disk quotas dquot_6.6.0
[    1.113300] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
[    1.113300] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
[    1.127243] pnp: PnP ACPI: disabled
[    1.127243] pnp: PnP ACPI: disabled
[    1.137860] NET: Registered protocol family 2
[    1.137860] NET: Registered protocol family 2
[    1.146910] TCP established hash table entries: 8192 (order: 4, 65536 bytes)
[    1.146910] TCP established hash table entries: 8192 (order: 4, 65536 bytes)
[    1.161135] TCP bind hash table entries: 8192 (order: 5, 131072 bytes)
[    1.161135] TCP bind hash table entries: 8192 (order: 5, 131072 bytes)
[    1.174334] TCP: Hash tables configured (established 8192 bind 8192)
[    1.174334] TCP: Hash tables configured (established 8192 bind 8192)
[    1.187174] UDP hash table entries: 512 (order: 2, 16384 bytes)
[    1.187174] UDP hash table entries: 512 (order: 2, 16384 bytes)
[    1.199082] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes)
[    1.199082] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes)
[    1.211935] NET: Registered protocol family 1
[    1.211935] NET: Registered protocol family 1
[    1.220881] RPC: Registered named UNIX socket transport module.
[    1.220881] RPC: Registered named UNIX socket transport module.
[    1.232774] RPC: Registered udp transport module.
[    1.232774] RPC: Registered udp transport module.
[    1.242227] RPC: Registered tcp transport module.
[    1.242227] RPC: Registered tcp transport module.
[    1.251672] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    1.251672] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    1.265071] kvm [1]: 8-bit VMID
[    1.265071] kvm [1]: 8-bit VMID
[    1.271374] kvm [1]: IDMAP page: 3094d000
[    1.271374] kvm [1]: IDMAP page: 3094d000
[    1.279425] kvm [1]: HYP VA range: 800000000000:ffffffffffff
[    1.279425] kvm [1]: HYP VA range: 800000000000:ffffffffffff
[    1.291254] kvm [1]: Hyp mode initialized successfully
[    1.291254] kvm [1]: Hyp mode initialized successfully
[    1.301597] kvm [1]: virtual timer IRQ3
[    1.301597] kvm [1]: virtual timer IRQ3
[    1.310556] audit: initializing netlink subsys (disabled)
[    1.310556] audit: initializing netlink subsys (disabled)
[    1.321483] audit: type=2000 audit(1.184:1): state=initialized audit_enabled=0 res=1
[    1.321483] audit: type=2000 audit(1.184:1): state=initialized audit_enabled=0 res=1
[    1.321642] workingset: timestamp_bits=44 max_order=18 bucket_order=0
[    1.321642] workingset: timestamp_bits=44 max_order=18 bucket_order=0
[    1.325702] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    1.325702] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    1.326039] NFS: Registering the id_resolver key type
[    1.326039] NFS: Registering the id_resolver key type
[    1.326055] Key type id_resolver registered
[    1.326055] Key type id_resolver registered
[    1.326056] Key type id_legacy registered
[    1.326056] Key type id_legacy registered
[    1.326062] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
[    1.326062] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
[    1.326176] 9p: Installing v9fs 9p2000 file system support
[    1.326176] 9p: Installing v9fs 9p2000 file system support
[    1.337786] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
[    1.337786] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
[    1.337790] io scheduler noop registered
[    1.337790] io scheduler noop registered
[    1.337907] io scheduler cfq registered (default)
[    1.337907] io scheduler cfq registered (default)
[    1.337909] io scheduler mq-deadline registered
[    1.337909] io scheduler mq-deadline registered
[    1.351332] pl061_gpio f8b21000.gpio: PL061 GPIO chip @0x00000000f8b21000 registered
[    1.351332] pl061_gpio f8b21000.gpio: PL061 GPIO chip @0x00000000f8b21000 registered
[    1.351544] pl061_gpio f8b22000.gpio: PL061 GPIO chip @0x00000000f8b22000 registered
[    1.351544] pl061_gpio f8b22000.gpio: PL061 GPIO chip @0x00000000f8b22000 registered
[    1.351751] pl061_gpio f8b23000.gpio: PL061 GPIO chip @0x00000000f8b23000 registered
[    1.351751] pl061_gpio f8b23000.gpio: PL061 GPIO chip @0x00000000f8b23000 registered
[    1.351942] pl061_gpio f8b24000.gpio: PL061 GPIO chip @0x00000000f8b24000 registered
[    1.351942] pl061_gpio f8b24000.gpio: PL061 GPIO chip @0x00000000f8b24000 registered
[    1.352143] pl061_gpio f8b26000.gpio: PL061 GPIO chip @0x00000000f8b26000 registered
[    1.352143] pl061_gpio f8b26000.gpio: PL061 GPIO chip @0x00000000f8b26000 registered
[    1.352340] pl061_gpio f8b2a000.gpio: PL061 GPIO chip @0x00000000f8b2a000 registered
[    1.352340] pl061_gpio f8b2a000.gpio: PL061 GPIO chip @0x00000000f8b2a000 registered
[    1.354291] xenfs: not registering filesystem on non-xen platform
[    1.354291] xenfs: not registering filesystem on non-xen platform
[    1.356245] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
[    1.356245] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
[    1.357100] SuperH (H)SCI(F) driver initialized
[    1.357100] SuperH (H)SCI(F) driver initialized
[    1.357263] msm_serial: driver initialized
[    1.357263] msm_serial: driver initialized
[    1.361784] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    1.361784] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    1.365411] loop: module loaded
[    1.365411] loop: module loaded
[    1.365778] hisi_sas: driver version v1.6
[    1.365778] hisi_sas: driver version v1.6
[    1.366801] libphy: Fixed MDIO Bus: probed
[    1.366801] libphy: Fixed MDIO Bus: probed
[    1.367009] tun: Universal TUN/TAP device driver, 1.6
[    1.367009] tun: Universal TUN/TAP device driver, 1.6
[    1.429155] libphy: hix5hd2_mii_bus: probed
[    1.429155] libphy: hix5hd2_mii_bus: probed
[    1.429443] (unnamed net_device) (uninitialized): using random MAC address d2:86:1b:81:29:6f
[    1.429443] (unnamed net_device) (uninitialized): using random MAC address d2:86:1b:81:29:6f
[    1.436432] e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
[    1.436432] e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
[    1.436433] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
[    1.436433] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
[    1.436465] igb: Intel(R) Gigabit Ethernet Network Driver - version 5.4.0-k
[    1.436465] igb: Intel(R) Gigabit Ethernet Network Driver - version 5.4.0-k
[    1.436466] igb: Copyright (c) 2007-2014 Intel Corporation.
[    1.436466] igb: Copyright (c) 2007-2014 Intel Corporation.
[    1.436489] igbvf: Intel(R) Gigabit Virtual Function Network Driver - version 2.4.0-k
[    1.436489] igbvf: Intel(R) Gigabit Virtual Function Network Driver - version 2.4.0-k
[    1.436490] igbvf: Copyright (c) 2009 - 2012 Intel Corporation.
[    1.436490] igbvf: Copyright (c) 2009 - 2012 Intel Corporation.
[    1.436512] sky2: driver version 1.30
[    1.436512] sky2: driver version 1.30
[    1.436789] VFIO - User Level meta-driver version: 0.3
[    1.436789] VFIO - User Level meta-driver version: 0.3
[    1.437409] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    1.437409] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    1.437411] ehci-pci: EHCI PCI platform driver
[    1.437411] ehci-pci: EHCI PCI platform driver
[    1.437434] ehci-platform: EHCI generic platform driver
[    1.437434] ehci-platform: EHCI generic platform driver
[    1.437473] ehci-exynos: EHCI EXYNOS driver
[    1.437473] ehci-exynos: EHCI EXYNOS driver
[    1.437508] ehci-msm: Qualcomm On-Chip EHCI Host Controller
[    1.437508] ehci-msm: Qualcomm On-Chip EHCI Host Controller
[    1.437540] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[    1.437540] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[    1.437569] ohci-pci: OHCI PCI platform driver
[    1.437569] ohci-pci: OHCI PCI platform driver
[    1.437594] ohci-platform: OHCI generic platform driver
[    1.437594] ohci-platform: OHCI generic platform driver
[    1.437626] ohci-exynos: OHCI EXYNOS driver
[    1.437626] ohci-exynos: OHCI EXYNOS driver
[    1.437789] usbcore: registered new interface driver usb-storage
[    1.437789] usbcore: registered new interface driver usb-storage
[    1.438413] i2c /dev entries driver
[    1.438413] i2c /dev entries driver
[    1.439377] lirc_dev: IR Remote Control driver registered, major 240
[    1.439377] lirc_dev: IR Remote Control driver registered, major 240
[    1.439379] IR NEC protocol handler initialized
[    1.439379] IR NEC protocol handler initialized
[    1.439381] IR RC5(x/sz) protocol handler initialized
[    1.439381] IR RC5(x/sz) protocol handler initialized
[    1.439382] IR RC6 protocol handler initialized
[    1.439382] IR RC6 protocol handler initialized
[    1.439384] IR JVC protocol handler initialized
[    1.439384] IR JVC protocol handler initialized
[    1.439385] IR Sony protocol handler initialized
[    1.439385] IR Sony protocol handler initialized
[    1.439387] IR SANYO protocol handler initialized
[    1.439387] IR SANYO protocol handler initialized
[    1.439388] IR Sharp protocol handler initialized
[    1.439388] IR Sharp protocol handler initialized
[    1.439390] IR MCE Keyboard/mouse protocol handler initialized
[    1.439390] IR MCE Keyboard/mouse protocol handler initialized
[    1.439391] IR LIRC bridge handler initialized
[    1.439391] IR LIRC bridge handler initialized
[    1.439393] IR XMP protocol handler initialized
[    1.439393] IR XMP protocol handler initialized
[    1.439436] hix5hd2-ir f8001000.ir: no power-reg
[    1.439436] hix5hd2-ir f8001000.ir: no power-reg
[    1.439505] rc rc0: hix5hd2-ir as /devices/virtual/rc/rc0
[    1.439505] rc rc0: hix5hd2-ir as /devices/virtual/rc/rc0
[    1.439853] input: MCE IR Keyboard/Mouse (hix5hd2-ir) as /devices/virtual/input/input1
[    1.439853] input: MCE IR Keyboard/Mouse (hix5hd2-ir) as /devices/virtual/input/input1
[    1.440012] rc rc0: lirc_dev: driver ir-lirc-codec (hix5hd2-ir) registered at minor = 0
[    1.440012] rc rc0: lirc_dev: driver ir-lirc-codec (hix5hd2-ir) registered at minor = 0
[    1.440017] Registered IR keymap rc-empty
[    1.440017] Registered IR keymap rc-empty
[    1.440084] input: hix5hd2-ir as /devices/virtual/rc/rc0/input0
[    1.440084] input: hix5hd2-ir as /devices/virtual/rc/rc0/input0
[    1.440774] sdhci: Secure Digital Host Controller Interface driver
[    1.440774] sdhci: Secure Digital Host Controller Interface driver
[    1.440776] sdhci: Copyright(c) Pierre Ossman
[    1.440776] sdhci: Copyright(c) Pierre Ossman
[    1.440876] Synopsys Designware Multimedia Card Interface Driver
[    1.440876] Synopsys Designware Multimedia Card Interface Driver
[    1.440958] dw_mmc f9830000.mmc: fifo-depth property not found, using value of FIFOTH register as default
[    1.440958] dw_mmc f9830000.mmc: fifo-depth property not found, using value of FIFOTH register as default
[    1.441042] dw_mmc f9830000.mmc: IDMAC supports 32-bit address mode.
[    1.441042] dw_mmc f9830000.mmc: IDMAC supports 32-bit address mode.
[    1.441184] dw_mmc f9830000.mmc: Using internal DMA controller.
[    1.441184] dw_mmc f9830000.mmc: Using internal DMA controller.
[    1.441190] dw_mmc f9830000.mmc: Version ID is 270a
[    1.441190] dw_mmc f9830000.mmc: Version ID is 270a
[    1.441225] dw_mmc f9830000.mmc: DW MMC controller at irq 10,32 bit host data width,64 deep fifo
[    1.441225] dw_mmc f9830000.mmc: DW MMC controller at irq 10,32 bit host data width,64 deep fifo
[    1.457105] mmc_host mmc0: Bus speed (slot 0) = 25000000Hz (slot req 400000Hz, actual 390625HZ div = 32)
[    1.457105] mmc_host mmc0: Bus speed (slot 0) = 25000000Hz (slot req 400000Hz, actual 390625HZ div = 32)
[    1.489350] dw_mmc f9830000.mmc: 1 slots initialized
[    1.489350] dw_mmc f9830000.mmc: 1 slots initialized
[    1.489631] sdhci-pltfm: SDHCI platform and OF driver helper
[    1.489631] sdhci-pltfm: SDHCI platform and OF driver helper
[    1.500971] ledtrig-cpu: registered to indicate activity on CPUs
[    1.500971] ledtrig-cpu: registered to indicate activity on CPUs
[    1.501430] usbcore: registered new interface driver usbhid
[    1.501430] usbcore: registered new interface driver usbhid
[    1.501432] usbhid: USB HID core driver
[    1.501432] usbhid: USB HID core driver
[    1.502363] NET: Registered protocol family 17
[    1.502363] NET: Registered protocol family 17
[    1.502414] 9pnet: Installing 9P2000 support
[    1.502414] 9pnet: Installing 9P2000 support
[    1.502455] Key type dns_resolver registered
[    1.502455] Key type dns_resolver registered
[    1.502864] registered taskstats version 1
[    1.502864] registered taskstats version 1
[    1.504627] hctosys: unable to open rtc device (rtc0)
[    1.504627] hctosys: unable to open rtc device (rtc0)
[    1.504710] ALSA device list:
[    1.504710] ALSA device list:
[    1.504711]   No soundcards found.
[    1.504711]   No soundcards found.
[    1.776256] mmc_host mmc0: Bus speed (slot 0) = 25000000Hz (slot req 25000000Hz, actual 25000000HZ div = 0)
[    1.776256] mmc_host mmc0: Bus speed (slot 0) = 25000000Hz (slot req 25000000Hz, actual 25000000HZ div = 0)
[    1.818749] mmc0: new MMC card at address 0001
[    1.818749] mmc0: new MMC card at address 0001
[    1.819020] mmcblk0: mmc0:0001 8WPD3R 7.28 GiB 
[    1.819020] mmcblk0: mmc0:0001 8WPD3R 7.28 GiB 
[    1.819119] mmcblk0boot0: mmc0:0001 8WPD3R partition 1 4.00 MiB
[    1.819119] mmcblk0boot0: mmc0:0001 8WPD3R partition 1 4.00 MiB
[    1.819207] mmcblk0boot1: mmc0:0001 8WPD3R partition 2 4.00 MiB
[    1.819207] mmcblk0boot1: mmc0:0001 8WPD3R partition 2 4.00 MiB
[    1.838213]  mmcblk0: p1 p2 p3
[    1.838213]  mmcblk0: p1 p2 p3
[    2.346302] uart-pl011 f8b00000.serial: no DMA platform data
[    2.346302] uart-pl011 f8b00000.serial: no DMA platform data
[    2.584911] random: fast init done
[    2.584911] random: fast init done
[    2.685615] EXT4-fs (mmcblk0p3): recovery complete
[    2.685615] EXT4-fs (mmcblk0p3): recovery complete
[    2.697027] EXT4-fs (mmcblk0p3): mounted filesystem with ordered data mode. Opts: (null)
[    2.697027] EXT4-fs (mmcblk0p3): mounted filesystem with ordered data mode. Opts: (null)
[    2.713313] VFS: Mounted root (ext4 filesystem) on device 179:3.
[    2.713313] VFS: Mounted root (ext4 filesystem) on device 179:3.
[    2.727058] devtmpfs: mounted
[    2.727058] devtmpfs: mounted
[    2.733443] Freeing unused kernel memory: 1088K
[    2.733443] Freeing unused kernel memory: 1088K
[    4.489767] systemd[1]: System time before build time, advancing clock.
[    4.489767] systemd[1]: System time before build time, advancing clock.
[    4.790746] NET: Registered protocol family 10
[    4.790746] NET: Registered protocol family 10
[    4.800194] Segment Routing with IPv6
[    4.800194] Segment Routing with IPv6
[    4.904533] systemd[1]: systemd 232 running in system mode. (+PAM -AUDIT -SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP -LIBCRYPTSETUP -GCRYPT -GNUTLS +ACL +XZ -LZ4 -SECCOMP +BLKID -ELFUTILS +KMOD )
[    4.904533] systemd[1]: systemd 232 running in system mode. (+PAM -AUDIT -SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP -LIBCRYPTSETUP -GCRYPT -GNUTLS +ACL +XZ -LZ4 -SECCOMP +BLKID -ELFUTILS +KMOD )
[    4.940995] systemd[1]: Detected architecture arm64.
[    4.940995] systemd[1]: Detected architecture arm64.

Welcome to Reference-Platform-Build-X11 2.4+linaro!

[    4.966761] systemd[1]: Set hostname to <poplar>.
[    4.966761] systemd[1]: Set hostname to <poplar>.
[    5.816970] systemd[1]: Listening on /dev/initctl Compatibility Named Pipe.
[    5.816970] systemd[1]: Listening on /dev/initctl Compatibility Named Pipe.
[  OK  ] Listening on /dev/initctl Compatibility Named Pipe.
[    5.845285] systemd[1]: Listening on Journal Socket.
[    5.845285] systemd[1]: Listening on Journal Socket.
[  OK  ] Listening on Journal Socket.
[    5.869278] systemd[1]: Listening on Network Service Netlink Socket.
[    5.869278] systemd[1]: Listening on Network Service Netlink Socket.
[  OK  ] Listening on Network Service Netlink Socket.
[    5.897104] systemd[1]: Reached target Swap.
[    5.897104] systemd[1]: Reached target Swap.
[  OK  ] Reached target Swap.
[    5.917183] systemd[1]: Listening on udev Control Socket.
[    5.917183] systemd[1]: Listening on udev Control Socket.
[  OK  ] Listening on udev Control Socket.
[    5.941213] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
[    5.941213] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
[  OK  ] Started Forward Password Requests to Wall Directory Watch.
[    5.973167] systemd[1]: Listening on Journal Socket (/dev/log).
[    5.973167] systemd[1]: Listening on Journal Socket (/dev/log).
[  OK  ] Listening on Journal Socket (/dev/log).
[  OK  ] Listening on udev Kernel Socket.
[  OK  ] Listening on Journal Audit Socket.
[  OK  ] Started Dispatch Password Requests to Console Directory Watch.
[  OK  ] Reached target Paths.
[  OK  ] Created slice User and Session Slice.
[  OK  ] Listening on Syslog Socket.
[  OK  ] Reached target Remote File Systems.
[  OK  ] Created slice System Slice.
[  OK  ] Reached target Slices.
         Starting Load Kernel Modules...
         Mounting Huge Pages File System...
         Mounting POSIX Message Queue File System...
[  OK  ] Created slice system-getty.slice.
         Starting Create list of required st��…ce nodes for the current kernel...
[    6.206103] fuse init (API version 7.26)
[    6.206103] fuse init (API version 7.26)
[  OK  ] Created slice system-serial\x2dgetty.slice.
         Mounting Debug File System...
         Starting Remount Root and Kernel File Systems...
[    6.263163] EXT4-fs (mmcblk0p3): re-mounted. Opts: (null)
[    6.263163] EXT4-fs (mmcblk0p3): re-mounted. Opts: (null)
         Starting Journal Service...
         Mounting Temporary Directory...
[  OK  ] Mounted Debug File System.
[  OK  ] Mounted Huge Pages File System.
[  OK  ] Mounted POSIX Message Queue File System.
[  OK  ] Mounted Temporary Directory.
[  OK  ] Started Journal Service.
[  OK  ] Started Load Kernel Modules.
[  OK  ] Started Create list of required sta��…vice nodes for the current kernel.
[  OK  ] Started Remount Root and Kernel File Systems.
         Starting udev Coldplug all Devices...
         Starting Create Static Device Nodes in /dev...
         Starting Apply Kernel Variables...
         Mounting FUSE Control File System...
         Mounting Configuration File System...
         Starting Flush Journal to Persistent Storage...
[  OK  ] Mounted FUSE Control File System.
[  OK  ] Mounted Configuration File System.
[    6.618667] systemd-journald[1228]: Received request to flush runtime journal from PID 1
[    6.618667] systemd-journald[1228]: Received request to flush runtime journal from PID 1
[  OK  ] Started Apply Kernel Variables.
[  OK  ] Started Flush Journal to Persistent Storage.
[  OK  ] Started Create Static Device Nodes in /dev.
         Starting udev Kernel Device Manager...
[  OK  ] Reached target Local File Systems (Pre).
         Mounting /var/volatile...
[  OK  ] Mounted /var/volatile.
[  OK  ] Started udev Coldplug all Devices.
         Starting Load/Save Random Seed...
[  OK  ] Reached target Local File Systems.
         Starting Create Volatile Files and Directories...
[  OK  ] Started Load/Save Random Seed.
[  OK  ] Started Create Volatile Files and Directories.
         Starting Update UTMP about System Boot/Shutdown...
         Starting Network Time Synchronization...
[  OK  ] Started Update UTMP about System Boot/Shutdown.
[  OK  ] Started udev Kernel Device Manager.
[  OK  ] Found device /dev/ttyAMA0.
[  OK  ] Started Network Time Synchronization.
[  OK  ] Reached target System Time Synchronized.
[  OK  ] Reached target System Initialization.
[  OK  ] Started Daily Cleanup of Temporary Directories.
[  OK  ] Listening on D-Bus System Message Bus Socket.
[  OK  ] Started dnf-automatic-download timer.
[  OK  ] Started dnf makecache timer.
[  OK  ] Started dnf-automatic-install timer.
[  OK  ] Listening on RPCbind Server Activation Socket.
         Starting sshd.socket.
[  OK  ] Started dnf-automatic-notifyonly timer.
[  OK  ] Reached target Timers.
         Starting Docker Socket for the API.
[  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
[  OK  ] Listening on Docker Socket for the API.
[  OK  ] Listening on sshd.socket.
[  OK  ] Reached target Sockets.
[  OK  ] Reached target Basic System.
         Starting Avahi mDNS/DNS-SD Stack...
[  OK  ] Reached target Containers.
[  OK  ] Started Kernel Logging Service.
[  OK  ] Started D-Bus System Message Bus.
[  OK  ] Started Avahi mDNS/DNS-SD Stack.
         Starting Network Manager...
         Starting Network Service...
[  OK  ] Started System Logging Service.
         Starting Login Service...
[  OK  ] Started Network Service.
[  OK  ] Started Login Service.
[  OK  ] Started Network Manager.
         Starting Network Manager Script Dispatcher Service...
[  OK  ] Reached target Network.
         Starting Docker Application Container Engine...
         Starting DNS forwarder and DHCP server...
         Starting Network Name Resolution...
         Starting Permit User Sessions...
         Starting Berkeley Internet Name Domain (DNS)...
[  OK  ] Started DNS forwarder and DHCP server.
[  OK  ] Started Permit User Sessions.
[  OK  ] Started Getty on tty1.
[  OK  ] Started Serial Getty on ttyAMA0.
[  OK  ] Started Network Name Resolution.
[  OK  ] Started Network Manager Script Dispatcher Service.
         Starting Hostname Service...
[  OK  ] Started Hostname Service.
[   14.292387] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
[   14.292387] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
[   14.306243] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
[   14.306243] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
         Starting Authorization Manager...
[   15.333428] hisi-gmac f9841000.ethernet eth0: Link is Down
[   15.333428] hisi-gmac f9841000.ethernet eth0: Link is Down
[   16.357452] hisi-gmac f9841000.ethernet eth0: Link is Up - 100Mbps/Full - flow control rx/tx
[   16.357452] hisi-gmac f9841000.ethernet eth0: Link is Up - 100Mbps/Full - flow control rx/tx
[   16.374487] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[   16.374487] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready

Reference-Platform-Build-X11 2.4+linaro poplar ttyAMA0

poplar login: [   25.271050] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
[   25.271050] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
[   25.307847] Bridge firewalling registered
[   25.307847] Bridge firewalling registered
[   25.379657] nf_conntrack version 0.5.0 (8192 buckets, 32768 max)
[   25.379657] nf_conntrack version 0.5.0 (8192 buckets, 32768 max)
[   25.568530] ip_tables: (C) 2000-2006 Netfilter Core Team
[   25.568530] ip_tables: (C) 2000-2006 Netfilter Core Team
[   25.584575] audit: type=1325 audit(1496778812.774:2): table=filter family=2 entries=0
[   25.584575] audit: type=1325 audit(1496778812.774:2): table=filter family=2 entries=0
[   25.600394] audit: type=1300 audit(1496778812.774:2): arch=c00000b7 syscall=273 success=yes exit=0 a0=0 a1=419348 a2=0 a3=0 items=0 ppid=34 pid=2148 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=)
[   25.600394] audit: type=1300 audit(1496778812.774:2): arch=c00000b7 syscall=273 success=yes exit=0 a0=0 a1=419348 a2=0 a3=0 items=0 ppid=34 pid=2148 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=)
[   25.651806] audit: type=1327 audit(1496778812.774:2): proctitle=2F7362696E2F6D6F6470726F6265002D71002D2D0069707461626C655F66696C746572
[   25.651806] audit: type=1327 audit(1496778812.774:2): proctitle=2F7362696E2F6D6F6470726F6265002D71002D2D0069707461626C655F66696C746572
[   25.700488] audit: type=1325 audit(1496778812.890:3): table=nat family=2 entries=0
[   25.700488] audit: type=1325 audit(1496778812.890:3): table=nat family=2 entries=0
[   25.715807] audit: type=1300 audit(1496778812.890:3): arch=c00000b7 syscall=273 success=yes exit=0 a0=1 a1=419348 a2=0 a3=1 items=0 ppid=34 pid=2156 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=)
[   25.715807] audit: type=1300 audit(1496778812.890:3): arch=c00000b7 syscall=273 success=yes exit=0 a0=1 a1=419348 a2=0 a3=1 items=0 ppid=34 pid=2156 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=)
[   25.767263] audit: type=1327 audit(1496778812.890:3): proctitle=2F7362696E2F6D6F6470726F6265002D71002D2D0069707461626C655F6E6174
[   25.767263] audit: type=1327 audit(1496778812.890:3): proctitle=2F7362696E2F6D6F6470726F6265002D71002D2D0069707461626C655F6E6174
[   25.866452] audit: type=1325 audit(1496778813.058:4): table=nat family=2 entries=5
[   25.866452] audit: type=1325 audit(1496778813.058:4): table=nat family=2 entries=5
[   25.881742] audit: type=1300 audit(1496778813.058:4): arch=c00000b7 syscall=208 success=yes exit=0 a0=4 a1=0 a2=40 a3=191d5720 items=0 ppid=2030 pid=2177 auid=4294967295 uid=0 gid=0 euid=0 suid=0 f)
[   25.881742] audit: type=1300 audit(1496778813.058:4): arch=c00000b7 syscall=208 success=yes exit=0 a0=4 a1=0 a2=40 a3=191d5720 items=0 ppid=2030 pid=2177 auid=4294967295 uid=0 gid=0 euid=0 suid=0 f)
[   25.936490] audit: type=1327 audit(1496778813.058:4): proctitle=2F7573722F7362696E2F69707461626C6573002D2D77616974002D74006E6174002D4E00444F434B4552
[   25.936490] audit: type=1327 audit(1496778813.058:4): proctitle=2F7573722F7362696E2F69707461626C6573002D2D77616974002D74006E6174002D4E00444F434B4552
[   25.963313] audit: type=1325 audit(1496778813.058:5): table=filter family=2 entries=4
[   25.963313] audit: type=1325 audit(1496778813.058:5): table=filter family=2 entries=4
[   26.223611] IPv6: ADDRCONF(NETDEV_UP): docker0: link is not ready
[   26.223611] IPv6: ADDRCONF(NETDEV_UP): docker0: link is not ready

Reference-Platform-Build-X11 2.4+linaro poplar ttyAMA0

poplar login: 
Reference-Platform-Build-X11 2.4+linaro poplar ttyAMA0

poplar login: linaro
[  201.331018] kauditd_printk_skb: 38 callbacks suppressed
[  201.331018] kauditd_printk_skb: 38 callbacks suppressed
[  201.341747] audit: type=1006 audit(1496778988.524:18): pid=2252 uid=0 old-auid=4294967295 auid=1000 tty=(none) old-ses=4294967295 ses=1 res=1
[  201.341747] audit: type=1006 audit(1496778988.524:18): pid=2252 uid=0 old-auid=4294967295 auid=1000 tty=(none) old-ses=4294967295 ses=1 res=1
poplar:~$ 
poplar:~$ 





