### PR TITLE
linux: build and ship kselftests from the kernel used

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -1,0 +1,34 @@
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# kernel selftests dependencies
+DEPENDS += "libcap libcap-ng pkgconfig-native popt rsync-native util-linux \
+    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
+"
+
+inherit kernel-arch
+
+KSELFTESTS_ARGS = "-C ${S}/tools/testing/selftests INSTALL_PATH=${D}/opt/kselftests CC="${CC}" LD="${LD}" ARCH=${ARCH}"
+
+do_compile_append() {
+    # Make sure to install the user space API used by some tests
+    # but not properly declared as a build dependency
+    ${MAKE} -C ${S} ARCH=${ARCH} headers_install
+    ${MAKE} ${KSELFTESTS_ARGS}
+}
+
+do_install_append() {
+    ${MAKE} ${KSELFTESTS_ARGS} install
+    chown -R root:root ${D}
+    # fixup run_kselftest.sh due to spurious lines starting by "make[1]:"
+    sed -i '/^make/d' ${D}/opt/kselftests/run_kselftest.sh
+}
+
+PACKAGES =+ "kernel-selftests"
+FILES_kernel-selftests = "/opt/kselftests"
+
+PACKAGES =+ "kernel-selftests-dbg"
+FILES_kernel-selftests-dbg = "/opt/kselftests/*/.debug"
+
+RDEPENDS_kernel-selftests = "bash bc ncurses sudo"
+
+INSANE_SKIP_kernel-selftests = "already-stripped"

--- a/recipes-kernel/linux/linux-hikey-aosp_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_4.4.bb
@@ -1,4 +1,5 @@
 require linux.inc
+require kselftests.inc
 
 DESCRIPTION = "AOSP kernel for HiKey"
 

--- a/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
@@ -1,4 +1,5 @@
 require linux.inc
+require kselftests.inc
 
 DESCRIPTION = "AOSP kernel for HiKey"
 

--- a/recipes-kernel/linux/linux-hikey-lt_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-lt_4.4.bb
@@ -1,4 +1,5 @@
 require linux.inc
+require kselftests.inc
 
 DESCRIPTION = "HiSilicon Landing Team kernel for HiKey"
 

--- a/recipes-kernel/linux/linux-hikey-next_git.bb
+++ b/recipes-kernel/linux/linux-hikey-next_git.bb
@@ -1,4 +1,5 @@
 require linux.inc
+require kselftests.inc
 
 DESCRIPTION = "Linux next kernel for HiKey"
 

--- a/recipes-kernel/linux/linux-hikey-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-stable_4.9.bb
@@ -1,4 +1,5 @@
 require linux.inc
+require kselftests.inc
 
 DESCRIPTION = "4.9 LTS kernel for HiKey"
 


### PR DESCRIPTION
* add kselftests.inc to build kernel selftests. It is intended to be
  reused by all the kernel recipes that need kselftests to be provided.
  It's also co-installable with kselftests recipe, which provide the
  latest version, independently of the kernel used at runtime.
* require kselftests.inc in linux-hikey-* recipes.
