### PR TITLE
linux.inc: split kernel-headers package into a separate include

### DIFF
--- a/recipes-kernel/linux/linux-headers.inc
+++ b/recipes-kernel/linux/linux-headers.inc
@@ -1,0 +1,8 @@
+inherit kernel-arch
+
+do_install_append() {
+    oe_runmake headers_install INSTALL_HDR_PATH=${D}${exec_prefix}/src/linux-${KERNEL_VERSION} ARCH=$ARCH
+}
+
+PACKAGES =+ "kernel-headers"
+FILES_kernel-headers = "${exec_prefix}/src/linux*"

--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -201,7 +201,6 @@ do_configure_append() {
 EXTRA_OEMAKE = "${PARALLEL_MAKE} "
 
 do_install_append() {
-	oe_runmake headers_install INSTALL_HDR_PATH=${D}${exec_prefix}/src/linux-${KERNEL_VERSION} ARCH=$ARCH
 	oe_runmake firmware_install INSTALL_MOD_PATH=${D} ARCH=$ARCH
 	install -d ${D}/boot
 	make -C ${S} O=${B} ARCH=$ARCH dtbs || true
@@ -212,9 +211,6 @@ do_install_append() {
 
 	rm -f ${D}${KERNEL_SRC_PATH}/arch/*/vdso/vdso*.so
 }
-
-PACKAGES =+ "kernel-headers"
-FILES_kernel-headers = "${exec_prefix}/src/linux*"
 
 require recipes-kernel/linux/linux-dtb.inc
 


### PR DESCRIPTION
With Linux Mainline and Next, it's causing build issues:
|   INSTALL usr/include/video/ (3 files)
|   INSTALL usr/include/video/uvesafb.h/ (0 file)
| touch: cannot touch 'usr/include/video/uvesafb.h/.install': Not a directory
| scripts/Makefile.headersinst:116: recipe for target 'usr/include/video/uvesafb.h/.install' failed

Workaround the build failure by splitting the kernel-headers package into
a separate include. If kernel recipes need the kernel-headers, they can
include linux-headers.inc file.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>