### PR TITLE
mali450-userland: use hardlinks instead of symlinks to fix the issue with RPM packaging

### DIFF
--- a/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
+++ b/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
@@ -38,21 +38,24 @@ S = "${WORKDIR}/wayland-drm"
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
+# rpm doesn't set the correct arch for symlinks:
+#   https://github.com/96boards/meta-96boards/issues/156
+# For this reason we have to use hardlinks vs symlinks.
 do_install() {
     install -m 755 -d ${D}/${libdir}
     install ${S}/libMali.so ${D}/${libdir}
-    (cd ${D}/${libdir} && ln -sf libMali.so libEGL.so.1.4 \
-    && ln -sf libEGL.so.1.4 libEGL.so.1 \
-    && ln -sf libEGL.so.1 libEGL.so)
-    (cd ${D}/${libdir} && ln -sf libMali.so libGLESv1_CM.so.1.1 \
-    && ln -sf libGLESv1_CM.so.1.1 libGLESv1_CM.so.1 \
-    && ln -sf libGLESv1_CM.so.1 libGLESv1_CM.so)
-    (cd ${D}/${libdir} && ln -sf libMali.so libGLESv2.so.2.0 \
-    && ln -sf libGLESv2.so.2.0 libGLESv2.so.2 \
-    && ln -sf libGLESv2.so.2 libGLESv2.so)
-    (cd ${D}/${libdir} && ln -sf libMali.so libgbm.so.1 \
-    && ln -sf libgbm.so.1 libgbm.so)
-    (cd ${D}/${libdir} && ln -sf libMali.so libwayland-egl.so)
+    (cd ${D}/${libdir} && ln -f libMali.so libEGL.so.1.4 \
+    && ln -f libEGL.so.1.4 libEGL.so.1 \
+    && ln -f libEGL.so.1 libEGL.so)
+    (cd ${D}/${libdir} && ln -f libMali.so libGLESv1_CM.so.1.1 \
+    && ln -f libGLESv1_CM.so.1.1 libGLESv1_CM.so.1 \
+    && ln -f libGLESv1_CM.so.1 libGLESv1_CM.so)
+    (cd ${D}/${libdir} && ln -f libMali.so libGLESv2.so.2.0 \
+    && ln -f libGLESv2.so.2.0 libGLESv2.so.2 \
+    && ln -f libGLESv2.so.2 libGLESv2.so)
+    (cd ${D}/${libdir} && ln -f libMali.so libgbm.so.1 \
+    && ln -f libgbm.so.1 libgbm.so)
+    (cd ${D}/${libdir} && ln -f libMali.so libwayland-egl.so)
 
     install -D -m0644 ${WORKDIR}/50-mali.rules \
         ${D}/${base_prefix}/lib/udev/rules.d/50-mali.rules


### PR DESCRIPTION
This fixes https://github.com/96boards/meta-96boards/issues/156

This is needed to fix builds which use RPM package format for HiKey, RPB and RPB based builds in particular. E.g. [RPB build 71](https://ci.linaro.org/view/All/job/96boards-reference-platform-openembedded-morty/71/DISTRO=rpb,MACHINE=hikey,label=docker-jessie-amd64/) :
``Computing transaction...error: Can't install glmark2-2014.03+0+fa71af2dfa-r0@aarch64: no package provides libEGL.so()(64bit)``