### PR TITLE
Mali drivers moved

### DIFF
--- a/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
+++ b/recipes-graphics/mali-userland/mali450-userland_r6p0_01rel0.bb
@@ -27,7 +27,7 @@ DEPENDS = "libdrm wayland mesa"
 
 VER ?= "${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '64', 'hf', d)}"
 
-SRC_URI = " http://malideveloper.arm.com/downloads/drivers/binary/utgard/r6p0-01rel0/mali-450_r6p0-01rel0_linux_1+arm${VER}.tar.gz;destsuffix=mali;name=arm${VER} \
+SRC_URI = " https://developer.arm.com/-/media/Files/downloads/mali-drivers/user-space/hikey/mali450r6p001rel0linux1arm${VER}tar.gz;destsuffix=mali;name=arm${VER};downloadfilename=mali450r6p001rel0linux1arm${VER}.tar.gz \
             file://50-mali.rules \
 "
 

--- a/recipes-kernel/linux/linux-hikey_git.bb
+++ b/recipes-kernel/linux/linux-hikey_git.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/Linaro/rpk.git;protocol=https;branch=rpk-v4.9;name=k
 "
 
 SRC_URI_append_hikey = " \
-    http://malideveloper.arm.com/downloads/drivers/DX910/r6p0-01rel0/DX910-SW-99002-r6p0-01rel0.tgz;name=mali \
+    https://developer.arm.com/-/media/Files/downloads/mali-drivers/kernel/mali-utgard-gpu/DX910-SW-99002-r6p0-01rel0.tgz;name=mali \
     file://defconfig;subdir=git/kernel/configs \
     file://mali-450.conf;subdir=git/kernel/configs \
     file://END_USER_LICENCE_AGREEMENT.txt;subdir=git \


### PR DESCRIPTION
The URLs currently being used in meta-96boards are no longer accessible. Let's switch to https://developer.arm.com/-/media/Files/downloads/mali-drivers/* ones (see ).

Actually, iirc https://developer.arm.com/products/software/mali-drivers is pointing to the new locations for quite a while. Just the http://malideveloper.arm.com/downloads/drivers/* stopped working just now.

This change should be propagated to pyro and morty.

Thanks