### PR TITLE
linux-hikey960: bump SRCREV, fix do_configure

### DIFF
--- a/recipes-kernel/linux/linux-hikey960_git.bb
+++ b/recipes-kernel/linux/linux-hikey960_git.bb
@@ -3,10 +3,10 @@ require linux.inc
 DESCRIPTION = "96boards-hikey kernel for HiKey960"
 
 PV = "4.9+git${SRCPV}"
-SRCREV_kernel = "dfd2f77df3430ff6e70fd93f135fdf1da581601c"
+SRCREV_kernel = "e74c7e1b28b13056e7fb3c6d8901ba708efbec8d"
 SRCREV_FORMAT = "kernel"
 
-SRC_URI = "git://github.com/96boards-hikey/linux.git;protocol=https;branch=hikey960-v4.9;name=kernel \
+SRC_URI = "git://github.com/96boards-hikey/linux.git;protocol=https;branch=hikey960-v4.9;name=kernel;rebaseable=1 \
 "
 
 S = "${WORKDIR}/git"
@@ -57,5 +57,6 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
+    install -d ${DEPLOY_DIR_IMAGE} 
     cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
 }


### PR DESCRIPTION
Bump SRCREV to get a revision that isn't rebased away and fixes USB host as well. Fix do_configure to create DEPLOY_DIR_IMAGE before trying to copy something into it.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>