### PR TITLE
[morty] linux: copy defconfig on deploy stage

### DIFF
--- a/recipes-kernel/linux/linux-hikey-aosp_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_4.4.bb
@@ -70,5 +70,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
@@ -69,5 +69,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-lt_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-lt_4.4.bb
@@ -71,5 +71,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-lts_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-lts_4.4.bb
@@ -71,5 +71,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-mainline_git.bb
+++ b/recipes-kernel/linux/linux-hikey-mainline_git.bb
@@ -63,5 +63,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-next_git.bb
+++ b/recipes-kernel/linux/linux-hikey-next_git.bb
@@ -63,5 +63,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-stable-rc_4.9.bb
@@ -69,5 +69,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-stable_4.9.bb
@@ -69,5 +69,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey960_git.bb
+++ b/recipes-kernel/linux/linux-hikey960_git.bb
@@ -57,6 +57,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    install -d ${DEPLOY_DIR_IMAGE} 
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey_git.bb
+++ b/recipes-kernel/linux/linux-hikey_git.bb
@@ -94,5 +94,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-poplar_git.bb
+++ b/recipes-kernel/linux/linux-poplar_git.bb
@@ -57,7 +57,6 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
 }
 
 # Create a 128M boot image. block size is 1024. (128*1024=131072)
@@ -66,6 +65,8 @@ BOOT_IMAGE_BASE_NAME = "boot-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
 BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 
 do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
+
     # Create boot image
     mkfs.vfat -F32 -n "boot" -C ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img ${BOOT_IMAGE_SIZE}
 


### PR DESCRIPTION
A rather unexpected error appeared when building the kernel
(almost) directly:
  cp: cannot create regular file '/oe/rpb-x11/morty/b-hikey/tmp-rpb-glibc/deploy/images/hikey': No such file or directory
  | WARNING: /oe/rpb-x11/morty/b-hikey/tmp-rpb-glibc/work/hikey-linaro-linux/linux-hikey/4.9+gitAUTOINC+04ec80a78d-r0/temp/run.do_configure.5148:1 exit 1 from 'cp -a /oe/rpb-x11/morty/b-hikey/tmp-rpb-glibc/work/hikey-linaro-linux/linux-hikey/4.9+gitAUTOINC+04ec80a78d-r0/build/defconfig /oe/rpb-x11/morty/b-hikey/tmp-rpb-glibc/deploy/images/hikey'

Copying the file failed because the directory does not exist.
Every successive bitbake (with the same target) fails exactly
the same way. It only succeeds after creating that directory.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>