### PR TITLE
linux: copy defconfig on deploy stage

### DIFF
--- a/recipes-kernel/linux/linux-hikey-aosp_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_4.4.bb
@@ -70,5 +70,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
@@ -69,5 +69,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-lt_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-lt_4.4.bb
@@ -71,5 +71,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-lts_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-lts_4.4.bb
@@ -71,5 +71,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-mainline_git.bb
+++ b/recipes-kernel/linux/linux-hikey-mainline_git.bb
@@ -63,5 +63,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-next_git.bb
+++ b/recipes-kernel/linux/linux-hikey-next_git.bb
@@ -63,5 +63,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-stable-rc_4.9.bb
@@ -69,5 +69,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-stable_4.9.bb
@@ -69,5 +69,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey960_git.bb
+++ b/recipes-kernel/linux/linux-hikey960_git.bb
@@ -57,6 +57,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    install -d ${DEPLOY_DIR_IMAGE} 
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-hikey_git.bb
+++ b/recipes-kernel/linux/linux-hikey_git.bb
@@ -94,5 +94,8 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
 }

--- a/recipes-kernel/linux/linux-poplar_git.bb
+++ b/recipes-kernel/linux/linux-poplar_git.bb
@@ -57,7 +57,6 @@ do_configure() {
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
-    cp -a ${B}/defconfig ${DEPLOY_DIR_IMAGE}
 }
 
 # Create a 128M boot image. block size is 1024. (128*1024=131072)
@@ -66,6 +65,8 @@ BOOT_IMAGE_BASE_NAME = "boot-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
 BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 
 do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
+
     # Create boot image
     mkfs.vfat -F32 -n "boot" -C ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img ${BOOT_IMAGE_SIZE}
 


### PR DESCRIPTION
There were three problems with saving and copying the
defconfig in the configure phase:
1) the deploy directory may not exist by the time it's
   copied, and
2) it was wrong in the first place to deploy anything in the
   configure phase, and
3) DEPLOY_DIR_IMAGE should not be used in do_deploy, anyway.

This patch moves that whole operation to the deploy phase,
using the right DEPLOYDIR mechanism (sstate-safe).

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>