### PR TITLE
linux-hikey960: move to 4.13rc kernel

### DIFF
--- a/recipes-kernel/linux/linux-hikey960_git.bb
+++ b/recipes-kernel/linux/linux-hikey960_git.bb
@@ -2,12 +2,11 @@ require linux.inc
 
 DESCRIPTION = "96boards-hikey kernel for HiKey960"
 
-PV = "4.9+git${SRCPV}"
-SRCREV_kernel = "e74c7e1b28b13056e7fb3c6d8901ba708efbec8d"
+PV = "4.12+git${SRCPV}"
+SRCREV_kernel = "46931cb4a9c7d007c353e4585c2ef6a4cd0f2317"
 SRCREV_FORMAT = "kernel"
 
-SRC_URI = "git://github.com/96boards-hikey/linux.git;protocol=https;branch=hikey960-v4.9;name=kernel;rebaseable=1 \
-"
+SRC_URI = "git://github.com/96boards-hikey/linux.git;protocol=https;branch=hikey960-upstream-rebase;name=kernel;rebaseable=1"
 
 S = "${WORKDIR}/git"
 
@@ -22,7 +21,7 @@ do_configure() {
     # Make sure to disable debug info and enable ext4fs built-in
     sed -e '/CONFIG_EXT4_FS=/d' \
         -e '/CONFIG_DEBUG_INFO=/d' \
-        < ${S}/arch/arm64/configs/hikey960_defconfig \
+        < ${S}/arch/arm64/configs/defconfig \
         > ${B}/.config
 
     echo 'CONFIG_EXT4_FS=y' >> ${B}/.config


### PR DESCRIPTION
4.9 doesn't build and doesn't ship image and dtb, so move to 4.13rc

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>