### PR TITLE
linux-generic-mainline_git: fix db410c with mainline

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=https;branch=master;name=kernel \
+    file://0001-arm64-defconfig-enable-missing-HWSPINLOCK.patch \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "

--- a/recipes-kernel/linux/linux-hikey-aosp/0001-arm64-defconfig-enable-missing-HWSPINLOCK.patch
+++ b/recipes-kernel/linux/linux-hikey-aosp/0001-arm64-defconfig-enable-missing-HWSPINLOCK.patch
@@ -1,0 +1,36 @@
+From 673d90742278aad8b531c727cdefd232f7bc7077 Mon Sep 17 00:00:00 2001
+From: Georgi Djakov <georgi.djakov@linaro.org>
+Date: Wed, 19 Jul 2017 15:55:13 +0300
+Subject: [PATCH] arm64: defconfig: enable missing HWSPINLOCK
+
+The hardware spinlock drivers now depend on HWSPINLOCK (instead of
+selecting it), so we need to explicitly enable it after commit
+35fc8a07d7f9 ("Make HWSPINLOCK a menuconfig to ease disabling")
+
+Without HWSPINLOCK, various drivers are left with unsatisfied
+dependencies and Qcom boards using shared memory based communication
+to request regulators are failing to boot and mount rootfs.
+
+Fix this by explicitly enabling HWSPINLOCK in defconfig.
+
+Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
+Signed-off-by: Andy Gross <andy.gross@linaro.org>
+---
+ arch/arm64/configs/defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
+index 6c7d147eed54..b4ca115b3be1 100644
+--- a/arch/arm64/configs/defconfig
++++ b/arch/arm64/configs/defconfig
+@@ -476,6 +476,7 @@ CONFIG_QCOM_CLK_SMD_RPM=y
+ CONFIG_MSM_GCC_8916=y
+ CONFIG_MSM_GCC_8994=y
+ CONFIG_MSM_MMCC_8996=y
++CONFIG_HWSPINLOCK=y
+ CONFIG_HWSPINLOCK_QCOM=y
+ CONFIG_ARM_MHU=y
+ CONFIG_PLATFORM_MHU=y
+-- 
+2.11.0
+


### PR DESCRIPTION
the defconfig patch should reach mainline soon, in the mean time it is needed to
get mainline to work on db410c.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>