### PR TITLE
linux-*: fix do_configure() for kselftest-merge

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -66,9 +66,9 @@ do_configure() {
         ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
     fi
 
-    oe_runmake -C ${S} O=${B} kselftest-merge
-
     oe_runmake -C ${S} O=${B} olddefconfig
+
+    oe_runmake -C ${S} O=${B} kselftest-merge
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig

--- a/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-aosp_4.9.bb
@@ -63,9 +63,9 @@ do_configure() {
         ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
     fi
 
-    oe_runmake -C ${S} O=${B} kselftest-merge
-
     oe_runmake -C ${S} O=${B} olddefconfig
+
+    oe_runmake -C ${S} O=${B} kselftest-merge
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig

--- a/recipes-kernel/linux/linux-hikey-next_git.bb
+++ b/recipes-kernel/linux/linux-hikey-next_git.bb
@@ -57,9 +57,9 @@ do_configure() {
         ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
     fi
 
-    oe_runmake -C ${S} O=${B} kselftest-merge
-
     oe_runmake -C ${S} O=${B} olddefconfig
+
+    oe_runmake -C ${S} O=${B} kselftest-merge
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig

--- a/recipes-kernel/linux/linux-hikey-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-stable-rc_4.9.bb
@@ -63,9 +63,9 @@ do_configure() {
         ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
     fi
 
-    oe_runmake -C ${S} O=${B} kselftest-merge
-
     oe_runmake -C ${S} O=${B} olddefconfig
+
+    oe_runmake -C ${S} O=${B} kselftest-merge
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig

--- a/recipes-kernel/linux/linux-hikey-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-hikey-stable_4.9.bb
@@ -63,9 +63,9 @@ do_configure() {
         ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
     fi
 
-    oe_runmake -C ${S} O=${B} kselftest-merge
-
     oe_runmake -C ${S} O=${B} olddefconfig
+
+    oe_runmake -C ${S} O=${B} kselftest-merge
 
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig


### PR DESCRIPTION
hi @fboudra ,

the latest images are still broken, and I am still looking at it.. however here are 2 patches that can already be merged. 

nico