### PR TITLE
OrangePi i96 initial support

### DIFF
--- a/conf/machine/orangepi-i96.conf
+++ b/conf/machine/orangepi-i96.conf
@@ -1,0 +1,40 @@
+#@TYPE: Machine
+#@NAME: OrangePi i96 machine
+#@DESCRIPTION: OrangePi i96 machine
+
+require conf/machine/include/tune-cortexa5.inc
+
+PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
+
+XSERVER ?= "xserver-xorg \
+            mesa-driver-swrast \
+            xf86-input-evdev \
+            xf86-video-fbdev"
+
+MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi-i96"
+
+KERNEL_IMAGETYPE = "zImage"
+#KERNEL_DEVICETREE = "currently-uses-a-concatenated-dt"
+
+UBOOT_MACHINE = "rda8810_config"
+UBOOT_SUFFIX = "rda"
+
+# TODO: Switch this to LS-UART1 and reduce to 115200 (921600 is needed
+#       on ttyS0 in order to match speeds with the boot ROM output
+SERIAL_CONSOLE = "921600 ttyS0"
+
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "\
+    u-boot-orangepi-i96 \
+"
+
+CMDLINE_ROOT_EMMC   = "mmcblk0p2"
+CMDLINE ?= "console=ttyS0,921600 root=/dev/${CMDLINE_ROOT_EMMC} rootwait rw quiet"
+
+# Fastboot expects an ext4 image, which needs to be 4096 bytes aligned
+IMAGE_FSTYPES_append = " ext4.gz"
+IMAGE_ROOTFS_ALIGNMENT = "4096"
+EXTRA_IMAGECMD_ext4 += " -L rootfs "
+
+EXTRA_IMAGEDEPENDS = "u-boot-orangepi-i96"

--- a/recipes-bsp/u-boot/u-boot-orangepi-i96.bb
+++ b/recipes-bsp/u-boot/u-boot-orangepi-i96.bb
@@ -1,0 +1,35 @@
+require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
+
+SUMMARY = "U-Boot bootloader for OrangePi i96"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=1707d6db1d42237583f50183a5651ecb"
+
+SRC_URI = "git://github.com/daniel-thompson/u-boot.git;nobranch=1"
+SRCREV = "976c9ecfc85a17ea4681c1eb2d1cf8f12251311b"
+
+PV = "v2012.04.01+git${SRCPV}"
+
+# u-boot needs devtree compiler to parse dts files
+DEPENDS += "dtc-native bc-native"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# The toolset libraries use the hard float ABI but u-boot is built with
+# the soft float ABI  and liberally uses intrinsics. We need to use a
+# private libgcc in order to get link compatible intrinsics.
+EXTRA_OEMAKE += 'USE_PRIVATE_LIBGCC=yes'
+
+S = "${WORKDIR}/git"
+
+# OrangePi u-boot doesn't actually support extlinux yet (but it will
+# when/if it is updated to the latest version)
+UBOOT_EXTLINUX ??= "1"
+UBOOT_EXTLINUX_LABELS ??= "default"
+UBOOT_EXTLINUX_KERNEL_IMAGE_default ??= "../zImage"
+UBOOT_EXTLINUX_MENU_DESCRIPTION_default ??= "Linux Default"
+UBOOT_EXTLINUX_FDTDIR ??= "../"
+UBOOT_EXTLINUX_KERNEL_ARGS ??= "append console=ttyS0,921600"
+UBOOT_EXTLINUX_ROOT ??= "root=/dev/mmcblk0p2 rootfstype=ext4 rootwait rw"

--- a/recipes-kernel/linux/linux-orangepi-i96_git.bb
+++ b/recipes-kernel/linux/linux-orangepi-i96_git.bb
@@ -1,0 +1,58 @@
+require linux.inc
+
+DESCRIPTION = "OrangePi i96 vendor kernel"
+
+PV = "3.10.62+git${SRCPV}"
+SRCREV_kernel = "b476a2c5bfb893aba3ee4daa840196a97898bf48"
+SRCREV_FORMAT = "kernel"
+
+SRC_URI = "git://github.com/daniel-thompson/linux.git;nobranch=1;name=kernel"
+
+S = "${WORKDIR}/git"
+
+COMPATIBLE_MACHINE = "orangepi-i96"
+KERNEL_IMAGETYPE ?= "zImage"
+
+# make[3]: *** [scripts/extract-cert] Error 1
+DEPENDS += "openssl-native"
+HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
+
+#LDFLAGS += "${TOOLCHAIN_OPTIONS}"
+
+do_configure() {
+    cp ${S}/arch/arm/configs/orangepi_i96_defconfig ${B}/.config
+
+    # Check for kernel config fragments. The assumption is that the config
+    # fragment will be specified with the absolute path. For example:
+    #   * ${WORKDIR}/config1.cfg
+    #   * ${S}/config2.cfg
+    # Iterate through the list of configs and make sure that you can find
+    # each one. If not then error out.
+    # NOTE: If you want to override a configuration that is kept in the kernel
+    #       with one from the OE meta data then you should make sure that the
+    #       OE meta data version (i.e. ${WORKDIR}/config1.cfg) is listed
+    #       after the in-kernel configuration fragment.
+    # Check if any config fragments are specified.
+    if [ ! -z "${KERNEL_CONFIG_FRAGMENTS}" ]; then
+        for f in ${KERNEL_CONFIG_FRAGMENTS}; do
+            # Check if the config fragment was copied into the WORKDIR from
+            # the OE meta data
+            if [ ! -e "$f" ]; then
+                echo "Could not find kernel config fragment $f"
+                exit 1
+            fi
+        done
+
+        # Now that all the fragments are located merge them.
+        ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
+    fi
+
+    oe_runmake -C ${S} O=${B} olddefconfig
+
+    bbplain "Saving defconfig to:\n${B}/defconfig"
+    oe_runmake -C ${B} savedefconfig
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
+}


### PR DESCRIPTION
Initial support is based on the vendor kernel and u-boot.

The vendor code currently has minimal changes, however they are modified to support gcc-7.