### PR TITLE
Create recovery image for Juno

### DIFF
--- a/recipes-bsp/atf/atf-juno_git.bb
+++ b/recipes-bsp/atf/atf-juno_git.bb
@@ -1,3 +1,5 @@
+inherit deploy
+
 require atf.inc
 
 DESCRIPTION = "ARM Trusted Firmware Juno"
@@ -6,7 +8,7 @@ LIC_FILES_CHKSUM = "file://license.rst;md5=33065335ea03d977d0569f270b39603e"
 
 COMPATIBLE_MACHINE = "juno"
 
-DEPENDS += "u-boot-juno"
+DEPENDS += "u-boot-juno zip-native"
 
 SRCREV = "b762fc7481c66b64eb98b6ff694d569e66253973"
 
@@ -20,10 +22,27 @@ S = "${WORKDIR}/git"
 
 # Building for Juno and FVP requires a special SCP firmware to be packed with
 # the FIP. You can Refer to the documentation here:
-# https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/user-guide.rst#id19
+# https://github.com/ARM-software/arm-trusted-firmware/blob/master/docs/user-guide.rst#building-a-fip-for-juno-and-fvp
 # This must be obtained from the Arm deliverables as released by Linaro:
 # https://community.arm.com/dev-platforms/b/documents/posts/linaro-release-notes-deprecated
 do_compile() {
     oe_runmake CROSS_COMPILE=${TARGET_PREFIX} all fip PLAT=${COMPATIBLE_MACHINE} SPD=none \
         SCP_BL2=${WORKDIR}/juno-oe-uboot/SOFTWARE/scp_bl2.bin BL33=${DEPLOY_DIR_IMAGE}/u-boot.bin
+
+    # Generate new FIP using our U-boot
+    ./tools/fiptool/fiptool update --nt-fw ${DEPLOY_DIR_IMAGE}/u-boot.bin \
+        build/${COMPATIBLE_MACHINE}/release/fip.bin
+
+    # Create new recovery image
+    cp -a build/${COMPATIBLE_MACHINE}/release/bl1.bin build/${COMPATIBLE_MACHINE}/release/fip.bin \
+        ${WORKDIR}/juno-oe-uboot/SOFTWARE/
+    cd ${WORKDIR}/juno-oe-uboot/
+    zip -r ${WORKDIR}/juno-oe-uboot.zip .
 }
+
+do_deploy() {
+    # Deploy recovery package
+    install -D -p -m0644 ${WORKDIR}/juno-oe-uboot.zip ${DEPLOYDIR}/juno-oe-uboot.zip
+}
+
+addtask deploy before do_build after do_compile

--- a/recipes-bsp/atf/atf.inc
+++ b/recipes-bsp/atf/atf.inc
@@ -1,5 +1,3 @@
-inherit deploy
-
 DEPENDS = "openssl-native"
 
 export LDFLAGS=""
@@ -14,13 +12,7 @@ do_install() {
     install -D -p -m0644 ${S}/build/${COMPATIBLE_MACHINE}/release/fip.bin ${D}${libdir}/atf/fip.bin
 }
 
-do_deploy() {
-    install -D -p -m0644 ${S}/build/${COMPATIBLE_MACHINE}/release/fip.bin ${DEPLOYDIR}/fip.bin
-}
-
 FILES_${PN} += "${libdir}/atf/*"
 
 # /usr/lib/atf/bl1.bin not shipped files. [installed-vs-shipped]
 INSANE_SKIP_${PN} += "installed-vs-shipped"
-
-addtask deploy before do_build after do_compile


### PR DESCRIPTION
The recovery image (with our U-boot) can be used to flash Juno.