### PR TITLE
linux-generic: enable CONFIG_POSIX_MQUEUE on arm32

### DIFF
--- a/recipes-kernel/linux/linux-generic-aosp_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-aosp_4.4.bb
@@ -45,6 +45,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-aosp_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-aosp_4.9.bb
@@ -44,6 +44,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-lsk_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lsk_4.4.bb
@@ -48,6 +48,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-lsk_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-lsk_4.9.bb
@@ -46,6 +46,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -39,6 +39,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -39,6 +39,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
@@ -48,6 +48,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
@@ -46,6 +46,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-stable_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.4.bb
@@ -48,6 +48,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.9.bb
@@ -46,6 +46,7 @@ do_configure() {
         # FIXME test for TI Beagle X15
         echo '# CONFIG_SERIAL_OMAP is not set' >> ${B}/.config
         echo '# CONFIG_SERIAL_OMAP_CONSOLE is not set' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config


### PR DESCRIPTION
In order to pass LTP on X15.

Signed-off-by: Dan Rue <dan.rue@linaro.org>