### PR TITLE
edk2-hikey: fix build with gcc 7

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey/0001-MdeModulePkg-UefiHiiLib-Fix-incorrect-comparison-exp.patch
+++ b/recipes-bsp/uefi/edk2-hikey/0001-MdeModulePkg-UefiHiiLib-Fix-incorrect-comparison-exp.patch
@@ -1,0 +1,45 @@
+From 73692710d50da1f421b0e6ddff784ca3135389b3 Mon Sep 17 00:00:00 2001
+From: Dandan Bi <dandan.bi@intel.com>
+Date: Sat, 1 Apr 2017 10:31:14 +0800
+Subject: [PATCH] MdeModulePkg/UefiHiiLib:Fix incorrect comparison expression
+
+Fix the incorrect comparison between pointer and constant zero character.
+
+https://bugzilla.tianocore.org/show_bug.cgi?id=416
+
+V2: The pointer StringPtr points to a string returned
+by ExtractConfig/ExportConfig, if it is NULL, function
+InternalHiiIfrValueAction will return FALSE. So in
+current usage model, the StringPtr can not be NULL before
+using it, so we can add ASSERT here.
+
+Cc: Eric Dong <eric.dong@intel.com>
+Cc: Liming Gao <liming.gao@intel.com>
+Contributed-under: TianoCore Contribution Agreement 1.0
+Signed-off-by: Dandan Bi <dandan.bi@intel.com>
+Reviewed-by: Eric Dong <eric.dong@intel.com>
+---
+Upstream-Status: Backport
+
+ MdeModulePkg/Library/UefiHiiLib/HiiLib.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/MdeModulePkg/Library/UefiHiiLib/HiiLib.c b/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
+index 8579501..46ca7bc 100644
+--- a/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
++++ b/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
+@@ -2180,8 +2180,9 @@ InternalHiiIfrValueAction (
+   }
+   
+   StringPtr = ConfigAltResp;
+-  
+-  while (StringPtr != L'\0') {
++  ASSERT (StringPtr != NULL);
++
++  while (*StringPtr != L'\0') {
+     //
+     // 1. Find <ConfigHdr> GUID=...&NAME=...&PATH=...
+     //
+-- 
+1.9.1
+

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -13,6 +13,7 @@ SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=hikey-aosp 
            git://github.com/96boards-hikey/arm-trusted-firmware.git;name=atf;branch=hikey;destsuffix=git/atf \
            git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=hikey-aosp;destsuffix=git/OpenPlatformPkg \
            git://git.linaro.org/uefi/uefi-tools.git;name=uefitools;destsuffix=git/uefi-tools \
+           file://0001-MdeModulePkg-UefiHiiLib-Fix-incorrect-comparison-exp.patch \
            file://grub.cfg.in \
           "
 


### PR DESCRIPTION
Backport patch that fixes build warnings with gcc 7.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>