### PR TITLE
edk2-hikey/hikey960: use DISTRO_NAME in the grub menuentry

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey/grub.cfg.in
+++ b/recipes-bsp/uefi/edk2-hikey/grub.cfg.in
@@ -1,7 +1,7 @@
 set default="0"
 set timeout=1
 
-menuentry 'CE Reference Platform (HiKey @DISTRO)' {
+menuentry '@DISTRO_NAME (HiKey)' {
     linux /boot/@KERNEL_IMAGETYPE console=tty0 @CMDLINE
     devicetree /boot/hi6220-hikey.dtb
 }

--- a/recipes-bsp/uefi/edk2-hikey960/grub.cfg.in
+++ b/recipes-bsp/uefi/edk2-hikey960/grub.cfg.in
@@ -1,7 +1,7 @@
 set default="0"
 set timeout=1
 
-menuentry 'CE Reference Platform (HiKey960 @DISTRO)' {
+menuentry '@DISTRO_NAME (HiKey960)' {
     linux /boot/@KERNEL_IMAGETYPE console=tty0 @CMDLINE
     devicetree /boot/hi3660-hikey960.dtb
 }

--- a/recipes-bsp/uefi/edk2-hikey960_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey960_git.bb
@@ -53,7 +53,7 @@ do_install() {
     install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${D}${libdir}/edk2/bl1.bin
 
     # Install grub configuration
-    sed -e "s|@DISTRO|${DISTRO}|" \
+    sed -e "s|@DISTRO_NAME|${DISTRO_NAME}|" \
         -e "s|@KERNEL_IMAGETYPE|${KERNEL_IMAGETYPE}|" \
         -e "s|@CMDLINE|${CMDLINE}|" \
         < ${WORKDIR}/grub.cfg.in \

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -43,7 +43,7 @@ do_install() {
     install -D -p -m0644 ${EDK2_DIR}/atf/build/${UEFIMACHINE}/release/bl1.bin ${D}${libdir}/edk2/bl1.bin
 
     # Install grub configuration
-    sed -e "s|@DISTRO|${DISTRO}|" \
+    sed -e "s|@DISTRO_NAME|${DISTRO_NAME}|" \
         -e "s|@KERNEL_IMAGETYPE|${KERNEL_IMAGETYPE}|" \
         -e "s|@CMDLINE|${CMDLINE}|" \
         < ${WORKDIR}/grub.cfg.in \


### PR DESCRIPTION
DISTRO_NAME provides more information about the distro selected during
the build process (e.g. Reference-Platform-Build-X11).

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>