### PR TITLE
atf: add zip-native

### DIFF
--- a/recipes-bsp/atf/atf.inc
+++ b/recipes-bsp/atf/atf.inc
@@ -1,4 +1,4 @@
-DEPENDS = "openssl-native"
+DEPENDS = "openssl-native zip-native"
 
 export LDFLAGS=""
 


### PR DESCRIPTION
zip is used in do_deploy.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>