### PR TITLE
linux-generic: update mainline and -next to 4.15

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -3,8 +3,8 @@ require kselftests.inc
 
 DESCRIPTION = "Generic Linux mainline kernel"
 
-PV = "4.14+git${SRCPV}"
-SRCREV_kernel = "bebc6082da0a9f5d47a1ea2edc099bf671058bd4"
+PV = "4.15+git${SRCPV}"
+SRCREV_kernel = "ead68f216110170ec729e2c4dec0aad6d38259d7"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -3,8 +3,8 @@ require kselftests.inc
 
 DESCRIPTION = "Generic Linux next kernel"
 
-PV = "4.14+git${SRCPV}"
-SRCREV_kernel = "c348a99ee55feac43b5b62a5957c6d8e2b6c3abe"
+PV = "4.15+git${SRCPV}"
+SRCREV_kernel = "3514267557aabe5f0a616e82ffed7dc066f67ece"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\


### PR DESCRIPTION
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>