### PR TITLE
cpupower: build failure, msgfmt: Command not found

### DIFF
--- a/recipes-kernel/cpupower/cpupower.bb
+++ b/recipes-kernel/cpupower/cpupower.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "cpupower is a collection of tools to examine and tune power \
 saving related features of your processor."
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
-DEPENDS = "pciutils"
+DEPENDS = "pciutils gettext-native"
 PROVIDES = "virtual/cpupower"
 
 inherit kernelsrc kernel-arch


### PR DESCRIPTION
ERROR: cpupower-1.0-r0 do_compile: oe_runmake failed
ERROR: cpupower-1.0-r0 do_compile: Function failed: do_compile (log file is located at /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/temp/log.do_compile.2344)
ERROR: Logfile of failure stored in: /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/temp/log.do_compile.2344
Log data follows:
| DEBUG: Executing shell function do_compile
| NOTE: make -j 8 -C /srv/rocko/oe/build/tmp-rpb-glibc/work-shared/hikey/kernel-source/tools/power/cpupower O=/srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0 CROSS=aarch64-linaro-linux- CC=aarch64-linaro-linux-gcc  --sysroot=/srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/recipe-sysroot LD=aarch64-linaro-linux-ld --sysroot=/srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/recipe-sysroot  AR=aarch64-linaro-linux-ar ARCH=arm64
| make: Entering directory '/srv/rocko/oe/build/tmp-rpb-glibc/work-shared/hikey/kernel-source/tools/power/cpupower'
|   MKDIR       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/lib/
|   MKDIR       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/po/
|   MKDIR       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/
|   MKDIR       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/
|   MKDIR       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/lib/cpufreq.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/lib/cpupower.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/lib/cpuidle.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/amd.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/msr.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/sysfs.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/misc.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/cpuid.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/pci.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/helpers/bitmask.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/nhm_idle.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/snb_idle.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/hsw_ext_idle.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/amd_fam14h_idle.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/cpuidle_sysfs.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/mperf_monitor.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/idle_monitor/cpupower-monitor.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/cpupower.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/cpufreq-info.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/cpufreq-set.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/cpupower-set.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/cpupower-info.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/cpuidle-info.o
|   CC       /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/utils/cpuidle-set.o
|   MSGFMT   /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/po/de.gmo
| make: msgfmt: Command not found
|   MSGFMT   /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/po/fr.gmo
| Makefile:239: recipe for target '/srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/po/de.gmo' failed
| make: *** [/srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/po/de.gmo] Error 127
| make: *** Waiting for unfinished jobs....
| make: msgfmt: Command not found
| Makefile:239: recipe for target '/srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/po/fr.gmo' failed
| make: *** [/srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/cpupower-1.0/po/fr.gmo] Error 127
| make: *** wait: No child processes.  Stop.
| ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.
| ERROR: Function failed: do_compile (log file is located at /srv/rocko/oe/build/tmp-rpb-glibc/work/hikey-linaro-linux/cpupower/1.0-r0/temp/log.do_compile.2344)
ERROR: Task (/srv/rocko/oe/build/conf/../../layers/meta-96boards/recipes-kernel/cpupower/cpupower.bb:do_compile) failed with exit code '1'

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>