### PR TITLE
linux-generic*: enable FUSE_FS=m for x86

### DIFF
--- a/recipes-kernel/linux/linux-generic-lsk-rt-test_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt-test_4.14.bb
@@ -42,6 +42,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-rt-test_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt-test_4.4.bb
@@ -50,6 +50,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-rt-test_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt-test_4.9.bb
@@ -48,6 +48,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt_4.14.bb
@@ -42,6 +42,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-rt_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt_4.4.bb
@@ -50,6 +50,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-rt_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt_4.9.bb
@@ -48,6 +48,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-test_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-test_4.14.bb
@@ -42,6 +42,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-test_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-test_4.4.bb
@@ -50,6 +50,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk-test_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-test_4.9.bb
@@ -48,6 +48,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk_4.14.bb
@@ -42,6 +42,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lsk_4.4.bb
@@ -50,6 +50,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lsk_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-lsk_4.9.bb
@@ -48,6 +48,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lts-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lts-rc_4.4.bb
@@ -49,6 +49,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-lts_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lts_4.4.bb
@@ -49,6 +49,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -51,6 +51,7 @@ do_configure() {
         # please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.
         echo 'CONFIG_UNWINDER_FRAME_POINTER=y' >> ${B}/.config
         echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -51,6 +51,7 @@ do_configure() {
         # please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.
         echo 'CONFIG_UNWINDER_FRAME_POINTER=y' >> ${B}/.config
         echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-stable-rt_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rt_4.4.bb
@@ -52,6 +52,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-stable-rt_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rt_4.9.bb
@@ -50,6 +50,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-stable_4.13.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.13.bb
@@ -43,6 +43,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-stable_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.14.bb
@@ -44,6 +44,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-stable_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.4.bb
@@ -97,6 +97,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 

--- a/recipes-kernel/linux/linux-generic-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.9.bb
@@ -50,6 +50,7 @@ do_configure() {
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
+        echo 'CONFIG_FUSE_FS=m' >> ${B}/.config
       ;;
     esac
 


### PR DESCRIPTION
FAILED Failed to start Load Kernel Modules.
See 'systemctl status systemd-modules-load.service' for details.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>