### PR TITLE
linux: use oe.utils.conditional instead of base_conditional

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -10,7 +10,7 @@ inherit kernel siteinfo
 
 # Set the verbosity of kernel messages during runtime
 # You can define CMDLINE_DEBUG in your local.conf or distro.conf to override this behaviour  
-CMDLINE_DEBUG ?= '${@base_conditional("DISTRO_TYPE", "release", "quiet", "debug", d)}'
+CMDLINE_DEBUG ?= '${@oe.utils.conditional("DISTRO_TYPE", "release", "quiet", "debug", d)}'
 CMDLINE_append = " ${CMDLINE_DEBUG} "
 
 # Kernel bootlogo is distro-specific (default is OE logo).


### PR DESCRIPTION
base_conditional was removed from OE-core (deprecated).

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>