### PR TITLE
linux.inc: use $KERNEL_PACKAGE_NAME for the kernel package name

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -17,7 +17,7 @@ CMDLINE_append = " ${CMDLINE_DEBUG} "
 # Logo resolution (qvga, vga, ...) is machine-specific.
 LOGO_SIZE ?= "."
 
-ALLOW_EMPTY_kernel-devicetree = "1"
+ALLOW_EMPTY_${KERNEL_PACKAGE_NAME}-devicetree = "1"
 
 python __anonymous () {
 
@@ -208,12 +208,12 @@ do_install_append() {
 	rm -f ${D}${KERNEL_SRC_PATH}/arch/*/vdso/vdso*.so
 }
 
-PACKAGES =+ "kernel-devicetree-overlays"
-FILES_kernel-devicetree-overlays = "/lib/firmware/*.dtbo /lib/firmware/*.dts"
-FILES_kernel-devicetree += "/boot/*.dtb"
+PACKAGES =+ "${KERNEL_PACKAGE_NAME}-devicetree-overlays"
+FILES_${KERNEL_PACKAGE_NAME}-devicetree-overlays = "/lib/firmware/*.dtbo /lib/firmware/*.dts"
+FILES_${KERNEL_PACKAGE_NAME}-devicetree += "/boot/*.dtb"
 
-RDEPENDS_kernel-image_append = " kernel-devicetree"
-RRECOMMENDS_kernel-image_append = " kernel-devicetree-overlays"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-image_append = " ${KERNEL_PACKAGE_NAME}-devicetree"
+RRECOMMENDS_${KERNEL_PACKAGE_NAME}-image_append = " ${KERNEL_PACKAGE_NAME}-devicetree-overlays"
 
 # Automatically depend on lzop/lz4-native if CONFIG_KERNEL_LZO/LZ4 is enabled
 python () {


### PR DESCRIPTION
The kernel class is now using $KERNEL_PACKAGE_NAME to set the default
kernel package name in order to allow alternate kernel flavors.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>