### PR TITLE
[Poplar] Fix URIs to github repositories for u-boot and Linux.

### DIFF
--- a/recipes-bsp/u-boot/u-boot-poplar.bb
+++ b/recipes-bsp/u-boot/u-boot-poplar.bb
@@ -8,7 +8,7 @@ DEPENDS += "dtc-native bc-native"
 SRCREV = "98469ebb7afaacc742d6f651f8e676e755672a63"
 PV = "v2017.09+git${SRCPV}"
 
-SRC_URI = "git://github.com/linaro/poplar-u-boot;protocol=git;branch=latest"
+SRC_URI = "git://github.com/96boards-poplar/u-boot;protocol=https;branch=alex/latest"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-poplar_git.bb
+++ b/recipes-kernel/linux/linux-poplar_git.bb
@@ -6,7 +6,7 @@ DEPENDS_append = " dosfstools-native mtools-native u-boot-poplar"
 
 PV = "4.9+git${SRCPV}"
 SRCREV = "e153b53cbd7047d7e6863c1850dda751f4a7f333"
-SRC_URI = "git://github.com/Linaro/poplar-linux.git;protocol=https;branch=poplar-4.9;name=kernel \
+SRC_URI = "git://github.com/96boards-poplar/linux.git;protocol=https;branch=poplar-4.9;name=kernel \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Building Yocto branch rocko for board poplar I got this errors:

```
ERROR: u-boot-poplar-v2017.09+gitAUTOINC+98469ebb7a-r0 do_fetch: Fetcher failure: Unable to find revision 98469ebb7afaacc742d6f651f8e676e755672a63 in branch latest even from upstream
ERROR: u-boot-poplar-v2017.09+gitAUTOINC+98469ebb7a-r0 do_fetch: Fetcher failure for URL: 'git://github.com/linaro/poplar-u-boot;protocol=git;branch=latest'. Unable to fetch URL from any source.
ERROR: u-boot-poplar-v2017.09+gitAUTOINC+98469ebb7a-r0 do_fetch: Function failed: base_do_fetch
ERROR: Logfile of failure stored in: /home/igalia/clopez/yocto/poplar/build_poplar/tmp/work/poplar-poky-linux/u-boot-poplar/v2017.09+gitAUTOINC+98469ebb7a-r0/temp/log.do_fetch.46598
ERROR: Task (/home/igalia/clopez/yocto/poplar/meta-96boards/recipes-bsp/u-boot/u-boot-poplar.bb:do_fetch) failed with exit code '1'
```

```
ERROR: linux-poplar-4.9+gitAUTOINC+e153b53cbd-r0 do_fetch: Fetcher failure: Unable to find revision e153b53cbd7047d7e6863c1850dda751f4a7f333 in branch poplar-4.9 even from upstream
ERROR: linux-poplar-4.9+gitAUTOINC+e153b53cbd-r0 do_fetch: Fetcher failure for URL: 'git://github.com/Linaro/poplar-linux.git;protocol=https;branch=poplar-4.9;name=kernel'. Unable to fetch URL from any source.
ERROR: linux-poplar-4.9+gitAUTOINC+e153b53cbd-r0 do_fetch: Function failed: base_do_fetch
ERROR: Logfile of failure stored in: /home/igalia/clopez/yocto/poplar/build_poplar/tmp/work/poplar-poky-linux/linux-poplar/4.9+gitAUTOINC+e153b53cbd-r0/temp/log.do_fetch.13069
ERROR: Task (/home/igalia/clopez/yocto/poplar/meta-96boards/recipes-kernel/linux/linux-poplar_git.bb:do_fetch) failed with exit code '1'
```

This patches fixes this.