### PR TITLE
linux-firmware: use nonarch_base_libdir instead of /lib

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -9,5 +9,5 @@ SRC_URI[TIInit_11.8.32.md5sum] = "b1e142773e8ef0537b93895ebe2fcae3"
 SRC_URI[TIInit_11.8.32.sha256sum] = "962322c05857ad6b1fb81467bdfc59c125e04a6a8eaabf7f24b742ddd68c3bfa"
 
 do_install_append_hikey() {
-     cp ${WORKDIR}/TIInit_11.8.32.bts ${D}/lib/firmware/ti-connectivity/
+     cp ${WORKDIR}/TIInit_11.8.32.bts ${D}${nonarch_base_libdir}/firmware/ti-connectivity/
 }


### PR DESCRIPTION
Hardcoded /lib is not compatible with usrmerge.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>