### PR TITLE
[morty] burn-boot/edk2/l-loader: deploy onto bootloader/ directly

### DIFF
--- a/recipes-bsp/burn-boot/burn-boot_git.bb
+++ b/recipes-bsp/burn-boot/burn-boot_git.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "python-pyserial"
 inherit deploy
 
 do_deploy() {
-    install -D -p -m 0755 ${S}/hisi-idt.py ${DEPLOYDIR}/hisi-idt.py
+    install -D -p -m 0755 ${S}/hisi-idt.py ${DEPLOYDIR}/bootloader/hisi-idt.py
 }
 
 addtask deploy before do_build after do_compile

--- a/recipes-bsp/l-loader/l-loader_git.bb
+++ b/recipes-bsp/l-loader/l-loader_git.bb
@@ -44,8 +44,8 @@ do_install() {
 }
 
 do_deploy() {
-    install -D -p -m0644 l-loader.bin ${DEPLOYDIR}/l-loader.bin
-    cp -a ptable-linux-*.img ${DEPLOYDIR}
+    install -D -p -m0644 l-loader.bin ${DEPLOYDIR}/bootloader/l-loader.bin
+    cp -a ptable-linux-*.img ${DEPLOYDIR}/bootloader/
 }
 
 addtask deploy before do_build after do_compile

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -60,7 +60,7 @@ BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
 do_deploy[depends] += "grub:do_deploy"
 do_deploy_append() {
     # Ship nvme.img with UEFI binaries for convenience
-    dd if=/dev/zero of=${DEPLOYDIR}/nvme.img bs=128 count=1024
+    dd if=/dev/zero of=${DEPLOYDIR}/bootloader/nvme.img bs=128 count=1024
 
     # Create boot image
     mkfs.vfat -F32 -n "boot" -C ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img ${BOOT_IMAGE_SIZE}
@@ -71,4 +71,8 @@ do_deploy_append() {
     chmod 644 ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.uefi.img
 
     (cd ${DEPLOYDIR} && ln -sf ${BOOT_IMAGE_BASE_NAME}.uefi.img boot-${MACHINE}.uefi.img)
+
+    # Fix up - move bootloader related files into a subdir
+    mv ${DEPLOYDIR}/fip.bin ${DEPLOYDIR}/bootloader/
+    rm -f ${DEPLOY_DIR_IMAGE}/grubaa64.efi
 }


### PR DESCRIPTION
Instead of having the builder script move the bootloader
stuff, deploy directly onto $DEPLOYDIR/bootloader/ so that
work across branches is the same.

Some of this is already in Rocko and master.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>