### PR TITLE
grub: (R)PROVIDE grub-efi

### DIFF
--- a/recipes-bsp/grub/grub_git.bb
+++ b/recipes-bsp/grub/grub_git.bb
@@ -1,5 +1,8 @@
 require recipes-bsp/grub/grub2.inc
 
+PROVIDES += "grub-efi"
+RPROVIDES_${PN} += "grub-efi"
+
 DEPENDS_class-target = "grub-native"
 
 DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
OE-core changes to automatically use grub-efi when MACHINE_FEATURES has 'efi'.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>