### PR TITLE
linux-generic-next: workaround emif-asm-offsets.s build error

### DIFF
--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -91,6 +91,13 @@ do_configure() {
     oe_runmake -C ${B} savedefconfig
 }
 
+# FIXME arm fails to build with ti-emif-sram driver
+# fatal error: can’t open ‘drivers/memory/emif-asm-offsets.s’ for writing: No such file or directory
+kernel_do_compile_prepend() {
+    unset CFLAGS CPPFLAGS CXXFLAGS LDFLAGS MACHINE
+    oe_runmake
+}
+
 do_deploy_append() {
     cp -a ${B}/defconfig ${DEPLOYDIR}
     cp -a ${B}/.config ${DEPLOYDIR}/config


### PR DESCRIPTION
See https://projects.linaro.org/browse/CTT-1081 and
https://bugs.linaro.org/show_bug.cgi?id=3717

Apply a workaround to avoid a build error:
cc1: fatal error: can’t open ‘drivers/memory/emif-asm-offsets.s’ for writing: No such file or directory

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>