### PR TITLE
linux-generic: remove sdm845 device tree

### DIFF
--- a/recipes-kernel/linux/linux-generic-lsk-rt-test_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt-test_4.14.bb
@@ -92,7 +92,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-lsk-rt_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-rt_4.14.bb
@@ -92,7 +92,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-lsk-test_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-test_4.14.bb
@@ -92,7 +92,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-lsk_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-lsk_4.14.bb
@@ -92,7 +92,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -100,7 +100,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -100,7 +100,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
@@ -94,7 +94,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.15.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.15.bb
@@ -100,7 +100,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
@@ -100,7 +100,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-stable_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.14.bb
@@ -94,7 +94,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-stable_4.15.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.15.bb
@@ -100,7 +100,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-stable_4.16.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.16.bb
@@ -100,7 +100,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -101,7 +101,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    rm -f ${B}/arch/arm64/boot/dts/qcom/*ipq8074* || true
+    rm -f ${B}/arch/arm64/boot/dts/qcom/{*ipq8074*,*sdm845*} || true
 }
 
 python do_package_prepend() {


### PR DESCRIPTION
In addition to ipq8074, remove sdm845. It's causing skales to error out.

Reported-by: Anders Roxell <anders.roxell@linaro.org>
Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>