### PR TITLE
fix 32bit optee-os install failure

### DIFF
--- a/recipes-security/optee/optee-os_git.bbappend
+++ b/recipes-security/optee/optee-os_git.bbappend
@@ -1,0 +1,2 @@
+# fixes 32bit OPTEE-OS build
+OPTEEOUTPUTMACHINE_hikey-32 = "hikey"


### PR DESCRIPTION
HiKey OPTEE generates output files in hikey directory irrespective of 64/32bit build