### PR TITLE
kselftests: pass --sysroot to Clang

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -14,6 +14,9 @@ do_compile_append() {
     # Make sure to install the user space API used by some tests
     # but not properly declared as a build dependency
     ${MAKE} -C ${S} ARCH=${ARCH} headers_install
+
+    # Specifying sysroot may help Clang find appropriate headers
+    export CLANG="clang --sysroot ${STAGING_DIR_TARGET}"
     ${MAKE} ${KSELFTESTS_ARGS}
 }
 


### PR DESCRIPTION
Using --sysroot allows Clang to find headers installed by OE,
instead of the host's.

This is one example where the host's headers are being used
(and then missing):
  In file included from test_l4lb_noinline.c:5:
  In file included from /usr/include/string.h:25:
  /usr/include/features.h:364:12: fatal error: 'sys/cdefs.h' file not found
  #  include <sys/cdefs.h>
             ^
  1 error generated.

Furthermore, those headers that are found, might be found on
the host, instead of OpenEmbedded's sysroot.

Bitbake already does this with GCC, e.g. in run.do_compile:
  export CC="aarch64-linaro-linux-gcc --sysroot=/oe/build/tmp-rpb-glibc/sysroots/hikey"

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>