### PR TITLE
kselftests: depend on clang-native for BPF target

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -1,7 +1,7 @@
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # kernel selftests dependencies
-DEPENDS += "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux \
+DEPENDS += "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux clang-native \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
 "
 


### PR DESCRIPTION
Some .o files needed by the bpf selftests were not being
produced because version 3.7+ of Clang was needed, with
support for the BPF target.

This has been done on the other kselftests packages for some
time now.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>