### PR TITLE
kselftests: depend on clang-native for BPF target

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -1,7 +1,7 @@
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # kernel selftests dependencies
-DEPENDS += "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux \
+DEPENDS += "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux clang-native \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
 "
 


### PR DESCRIPTION
Some .o files are needed by the bpf selftests.

Same reason change that was done in meta-rpb:
ff7af44cdb84 ("kselftests: depend on clang-native for BPF target")
URL:
https://github.com/96boards/meta-rpb/commit/ff7af44cdb84c6364fe0db81fe61215074dedb24

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>