### PR TITLE
kselftests: add uuidgen to RDEPENDS

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -38,6 +38,7 @@ FILES_kernel-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
 RDEPENDS_kernel-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc glibc-utils ncurses sudo"
 RDEPENDS_kernel-selftests =+ "python3-argparse python3-datetime python3-json python3-pprint python3-subprocess"
+RDEPENDS_kernel-selftests =+ "util-linux-uuidgen"
 RDEPENDS_kernel-selftests_append_x86 = " cpupower"
 RDEPENDS_kernel-selftests_append_x86-64 = " cpupower"
 


### PR DESCRIPTION
Kselftests net/rtnetlink.sh fails due to uuidgen isn't installed into
the rootfs:
./rtnetlink.sh: line 280: uuidgen: command not found

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>