### PR TITLE
kselftests: add cpupower to RDEPENDS

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -38,6 +38,8 @@ FILES_kernel-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
 RDEPENDS_kernel-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc glibc-utils ncurses sudo"
 RDEPENDS_kernel-selftests =+ "python3-argparse python3-datetime python3-json python3-pprint python3-subprocess"
+RDEPENDS_kernel-selftests_append_x86 = " cpupower"
+RDEPENDS_kernel-selftests_append_x86-64 = " cpupower"
 
 INSANE_SKIP_kernel-selftests = "already-stripped"
 # Ignore the QA error because kselftests/bpf/ requires object files


### PR DESCRIPTION
Kselftests intel_pstate uses cpupower.

test intel_pstate uses cpupower, add that to RDEPEND
cd /opt/kselftests/default-in-kernel/intel_pstate
./run.sh
./run.sh: line 79: cpupower: command not found

Looked at commit below from meta-rpb
79beb20ef4a9 ("kselftests-common: fix RDEPENDS on cpupower")
URL:
https://github.com/96boards/meta-rpb/commit/79beb20ef4a94b7f3b1c07aa89a2db67ff178673

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>