### PR TITLE
linux mainline/stable-rc/generic: enable KSM

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -61,6 +61,10 @@ do_configure() {
     # Make sure to enable NUMA
     echo 'CONFIG_NUMA=y' >> ${B}/.config
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -61,6 +61,10 @@ do_configure() {
     # Make sure to enable NUMA
     echo 'CONFIG_NUMA=y' >> ${B}/.config
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
@@ -55,6 +55,10 @@ do_configure() {
     # Make sure to enable NUMA
     echo 'CONFIG_NUMA=y' >> ${B}/.config
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
@@ -61,6 +61,10 @@ do_configure() {
     # Make sure to enable NUMA
     echo 'CONFIG_NUMA=y' >> ${B}/.config
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.17.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.17.bb
@@ -61,6 +61,10 @@ do_configure() {
     # Make sure to enable NUMA
     echo 'CONFIG_NUMA=y' >> ${B}/.config
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
@@ -105,6 +105,10 @@ do_configure() {
       ;;
     esac
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
@@ -61,6 +61,10 @@ do_configure() {
     # Make sure to enable NUMA
     echo 'CONFIG_NUMA=y' >> ${B}/.config
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg

--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -59,6 +59,10 @@ do_configure() {
     # Make sure to enable NUMA
     echo 'CONFIG_NUMA=y' >> ${B}/.config
 
+    # Enable KSM
+    # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
+    echo 'CONFIG_KSM=y' >> ${B}/.config
+
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:
     #   * ${WORKDIR}/config1.cfg


### PR DESCRIPTION
As per the documentation, Kernel Samepage Merging is a memory-saving de-duplication feature, enabled by `CONFIG_KSM=y` and activated via sysfs.

When enabled in the kernel, the default is to not do anything at all, until it is activated with:
```
echo 1 > /sys/kernel/mm/ksm/run
```

Available since 2.6.32. More information here: https://www.kernel.org/doc/Documentation/vm/ksm.txt