### PR TITLE
Revert "atf-juno: update, enable OPTEE"

### DIFF
--- a/recipes-bsp/atf/atf-juno_git.bb
+++ b/recipes-bsp/atf/atf-juno_git.bb
@@ -1,10 +1,8 @@
 DESCRIPTION = "ARM Trusted Firmware Juno"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://license.rst;md5=33065335ea03d977d0569f270b39603e"
-DEPENDS += "optee-os u-boot-juno zip-native"
-SRCREV = "e83769c07bb09b7727a36389c9dd92096860637e"
-
-PV = "1.4+git${SRCPV}"
+DEPENDS += "u-boot-juno zip-native"
+SRCREV = "b762fc7481c66b64eb98b6ff694d569e66253973"
 
 SRC_URI = "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https;name=atf;branch=master \
     http://releases.linaro.org/members/arm/platforms/17.04/juno-latest-oe-uboot.zip;name=junofip;subdir=juno-oe-uboot \
@@ -22,8 +20,6 @@ COMPATIBLE_MACHINE = "juno"
 
 # ATF requires u-boot.bin file. Ensure it's deployed before we compile.
 do_compile[depends] += "u-boot-juno:do_deploy"
-# Same for OP-TEE files.
-do_compile[depends] += "optee-os:do_deploy"
 
 # Building for Juno requires a special SCP firmware to be packed with FIP.
 # You can refer to the documentation here:
@@ -36,23 +32,15 @@ do_compile() {
       all \
       fip \
       PLAT=${COMPATIBLE_MACHINE} \
-      SPD=opteed \
+      SPD=none \
       SCP_BL2=${WORKDIR}/juno-oe-uboot/SOFTWARE/scp_bl2.bin \
-      BL32=${DEPLOY_DIR_IMAGE}/optee/tee-header_v2.bin \
-      BL32_EXTRA1=${DEPLOY_DIR_IMAGE}/optee/tee-pager_v2.bin \
-      BL32_EXTRA2=${DEPLOY_DIR_IMAGE}/optee/tee-pageable_v2.bin \
-      BL33=${DEPLOY_DIR_IMAGE}/u-boot.bin \
-      DEBUG=0 \
-      ARM_TSP_RAM_LOCATION=dram \
-      CSS_USE_SCMI_SDS_DRIVER=1
+      BL33=${DEPLOY_DIR_IMAGE}/u-boot.bin
 
     # Generate new FIP using our U-boot
     ./tools/fiptool/fiptool update \
       --nt-fw ${DEPLOY_DIR_IMAGE}/u-boot.bin \
       build/${COMPATIBLE_MACHINE}/release/fip.bin
 }
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # Ensure we deploy kernel/dtb before we create the recovery image.
 do_deploy[depends] += "virtual/kernel:do_deploy"


### PR DESCRIPTION
This reverts commit 51254c64135deb3009a5e152cac4460d2a835f21.

Juno has not been booting for a long time now [1]. Recent OE RPB jobs fail to boot [2], and even the original job [3] that proved that it worked, when resubmitted, does not work [4].

Reverting this commit gets Juno back on track.

[1] https://validation.linaro.org/results/query/+custom?entity=testjob&conditions=testjob__description__icontains__RPB%20OE%20boot%20juno%20rocko
[2] https://validation.linaro.org/scheduler/job/1881609
[3] https://validation.linaro.org/scheduler/job/1654389
[4] https://validation.linaro.org/scheduler/job/1883480

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>