### PR TITLE
[morty] Revert "atf-juno: update juno-latest-oe-uboot.zip to 18.04 release"

### DIFF
--- a/recipes-bsp/atf/atf-juno_git.bb
+++ b/recipes-bsp/atf/atf-juno_git.bb
@@ -5,10 +5,10 @@ DEPENDS += "u-boot-juno zip-native"
 SRCREV = "b762fc7481c66b64eb98b6ff694d569e66253973"
 
 SRC_URI = "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https;name=atf;branch=master \
-    http://releases.linaro.org/members/arm/platforms/18.04/juno-latest-oe-uboot.zip;name=junofip;subdir=juno-oe-uboot \
+    http://releases.linaro.org/members/arm/platforms/17.04/juno-latest-oe-uboot.zip;name=junofip;subdir=juno-oe-uboot \
 "
-SRC_URI[junofip.md5sum] = "1cf91f8719dbf966b0d7c2b5d6135792"
-SRC_URI[junofip.sha256sum] = "ff01941725f1f67910817a8ec88be9a2db9d132c50b2bb4d13291c471f30b91f"
+SRC_URI[junofip.md5sum] = "12fc772de457930fc60e42bdde97eb0a"
+SRC_URI[junofip.sha256sum] = "be1a3f8b72a0dd98ba1bf9f4fd5415d3adca052c60b090c5dccc178588ec43bc"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This reverts commit `5d6fbe382083fb3384883d1d748f437f6087bbe9`.

Currently, Morty only works with 17.04, as the following versions of the Juno recovery pack do not get along with the software versions as they are shipped with Morty:
* 17.07: https://lkft.validation.linaro.org/scheduler/job/299683
* 17.10: https://lkft.validation.linaro.org/scheduler/job/299656
* 18.01: https://lkft.validation.linaro.org/scheduler/job/299643
* 18.04: https://lkft.validation.linaro.org/scheduler/job/298978