### PR TITLE
kselftests: depend on elfutils (libelf.h)

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -1,7 +1,7 @@
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # kernel selftests dependencies
-DEPENDS += "fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux clang-native \
+DEPENDS += "elfutils fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux clang-native \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
 "
 


### PR DESCRIPTION
A lot of failures in BPF selftests are due to a missing
libelf.h, which is needed to construct libbpf.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>