### PR TITLE
kselftests: fix RDEPENDS for python3 packages

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -37,7 +37,7 @@ PACKAGES =+ "kernel-selftests-dbg"
 FILES_kernel-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
 RDEPENDS_kernel-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc glibc-utils ncurses sudo"
-RDEPENDS_kernel-selftests =+ "python3-argparse python3-datetime python3-json python3-pprint python3-subprocess"
+RDEPENDS_kernel-selftests =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_kernel-selftests =+ "util-linux-uuidgen"
 RDEPENDS_kernel-selftests_append_x86 = " cpupower"
 RDEPENDS_kernel-selftests_append_x86-64 = " cpupower"


### PR DESCRIPTION
In newer python3 argparse and subprocess have moved into python3-core.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>