### PR TITLE
linux: Drop patch from 4.4/4.9

### DIFF
--- a/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
@@ -17,7 +17,6 @@ SRC_URI = "\
     file://0001-selftests-ftrace-add-CONFIG_KPROBES-y-to-the-config-.patch \
     file://0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch \
     file://0001-selftests-create-cpufreq-kconfig-fragments.patch \
-    file://0001-selftests-sync-add-config-fragment-for-testing-sync-.patch \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
 "
 

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
@@ -17,7 +17,6 @@ SRC_URI = "\
     file://0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch \
     file://0001-selftests-gpio-add-config-fragment-for-gpio-mockup.patch \
     file://0001-selftests-create-cpufreq-kconfig-fragments.patch \
-    file://0001-selftests-sync-add-config-fragment-for-testing-sync-.patch \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
 "
 

--- a/recipes-kernel/linux/linux-generic-stable_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.4.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
     file://0001-selftests-ftrace-add-CONFIG_KPROBES-y-to-the-config-.patch \
     file://0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch \
     file://0001-selftests-create-cpufreq-kconfig-fragments.patch \
-    file://0001-selftests-sync-add-config-fragment-for-testing-sync-.patch \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
 "
 

--- a/recipes-kernel/linux/linux-generic-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.9.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
     file://0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch \
     file://0001-selftests-gpio-add-config-fragment-for-gpio-mockup.patch \
     file://0001-selftests-create-cpufreq-kconfig-fragments.patch \
-    file://0001-selftests-sync-add-config-fragment-for-testing-sync-.patch \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
 "
 


### PR DESCRIPTION
sync's config fragment finally made its way to reach these branches!

We first need to validate that the patch is actually dropped when GKH announces his RC branch.