### PR TITLE
linux: lkft: hikey 4.4: drop sync's config fragment patch

### DIFF
--- a/recipes-kernel/linux/linux-generic-lts-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-lts-rc_4.4.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
     file://0001-selftests-ftrace-add-CONFIG_KPROBES-y-to-the-config-.patch \
     file://0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch \
     file://0001-selftests-create-cpufreq-kconfig-fragments.patch \
-    file://0001-selftests-sync-add-config-fragment-for-testing-sync-.patch \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
 "
 


### PR DESCRIPTION
Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>