### PR TITLE
linux: linux-generic: remove config PLT for relocation

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -44,8 +44,6 @@ do_configure() {
         echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
-        # https://bugs.linaro.org/show_bug.cgi?id=3769
-        echo 'CONFIG_ARM_MODULE_PLTS=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -44,8 +44,6 @@ do_configure() {
         echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
-        # https://bugs.linaro.org/show_bug.cgi?id=3769
-        echo 'CONFIG_ARM_MODULE_PLTS=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.18.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.18.bb
@@ -44,8 +44,6 @@ do_configure() {
         echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
-        # https://bugs.linaro.org/show_bug.cgi?id=3769
-        echo 'CONFIG_ARM_MODULE_PLTS=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config


### PR DESCRIPTION
Patch in meta-96boards, c0d4c09ec75f ("linux-generic: direct branch
instr modules need PLT for relocation") enables config PLT for
relocation on arm/arm64.  It is now enabled by default in the upstream
kernel from release v4.18
We shouldn't enable config PLT for relocation for arm64 just because
there may be a chance to run into the issue. We get faster code with the
option turned off, which is what most people want. Then we can 'fix' the
issue upstream if we often hit this issue like we did for ARM.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>