### PR TITLE
lkft: Add 4.18 stable, update all stable kernel, config fragment too

### DIFF
--- a/recipes-kernel/linux/linux-generic-stable_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.14.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.14.y;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
@@ -19,6 +20,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|dragonboard-410c|hikey|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -55,9 +57,6 @@ do_configure() {
         echo 'CONFIG_IGB=y' >> ${B}/.config
       ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:

--- a/recipes-kernel/linux/linux-generic-stable_4.15.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.15.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.15.y;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "
@@ -18,6 +19,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -64,9 +66,6 @@ do_configure() {
         echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
       ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:

--- a/recipes-kernel/linux/linux-generic-stable_4.16.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.16.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.16.y;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "
@@ -18,6 +19,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -68,9 +70,6 @@ do_configure() {
         echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
       ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:

--- a/recipes-kernel/linux/linux-generic-stable_4.17.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.17.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.17.y;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "
@@ -18,6 +19,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -68,9 +70,6 @@ do_configure() {
         echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
       ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:

--- a/recipes-kernel/linux/linux-generic-stable_4.18.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.18.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.18.y;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "
@@ -18,6 +19,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -66,9 +68,6 @@ do_configure() {
         echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
       ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:

--- a/recipes-kernel/linux/linux-generic-stable_4.18.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.18.bb
@@ -1,0 +1,119 @@
+require linux.inc
+require kselftests.inc
+
+DESCRIPTION = "Generic 4.18 LTS kernel"
+
+PV = "4.18+git${SRCPV}"
+SRCREV_kernel = "94710cac0ef4ee177a63b5227664b38c95bbf703"
+SRCREV_FORMAT = "kernel"
+
+SRC_URI = "\
+    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.18.y;name=kernel \
+    file://distro-overrides.config;subdir=git/kernel/configs \
+    file://systemd.config;subdir=git/kernel/configs \
+"
+
+S = "${WORKDIR}/git"
+
+COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
+KERNEL_IMAGETYPE ?= "Image"
+KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/distro-overrides.config \
+    ${S}/kernel/configs/systemd.config \
+"
+
+# make[3]: *** [scripts/extract-cert] Error 1
+DEPENDS += "openssl-native"
+HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
+
+do_configure() {
+    touch ${B}/.scmversion ${S}/.scmversion
+
+    # While kernel.bbclass has an architecture mapping, we can't use it because
+    # the kernel config file has a different name.
+    case "${HOST_ARCH}" in
+      aarch64)
+        cp ${S}/arch/arm64/configs/defconfig ${B}/.config
+        # https://bugs.linaro.org/show_bug.cgi?id=3769
+        echo 'CONFIG_ARM64_MODULE_PLTS=y' >> ${B}/.config
+      ;;
+      arm)
+        cp ${S}/arch/arm/configs/multi_v7_defconfig ${B}/.config
+        echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
+        echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+      ;;
+      x86_64)
+        cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
+        echo 'CONFIG_IGB=y' >> ${B}/.config
+        # FIXME https://bugs.linaro.org/show_bug.cgi?id=3459
+        # x86 fails to build:
+        # | kernel-source/Makefile:938:
+        # *** "Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y,
+        # please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.
+        echo 'CONFIG_UNWINDER_FRAME_POINTER=y' >> ${B}/.config
+        echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
+      ;;
+      i686)
+        cp ${S}/arch/x86/configs/i386_defconfig ${B}/.config
+        echo 'CONFIG_IGB=y' >> ${B}/.config
+        # FIXME https://bugs.linaro.org/show_bug.cgi?id=3459
+        # x86 fails to build:
+        # | kernel-source/Makefile:938:
+        # *** "Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y,
+        # please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.
+        echo 'CONFIG_UNWINDER_FRAME_POINTER=y' >> ${B}/.config
+        echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
+      ;;
+    esac
+
+    # Make sure to enable NUMA
+    echo 'CONFIG_NUMA=y' >> ${B}/.config
+
+    # Check for kernel config fragments. The assumption is that the config
+    # fragment will be specified with the absolute path. For example:
+    #   * ${WORKDIR}/config1.cfg
+    #   * ${S}/config2.cfg
+    # Iterate through the list of configs and make sure that you can find
+    # each one. If not then error out.
+    # NOTE: If you want to override a configuration that is kept in the kernel
+    #       with one from the OE meta data then you should make sure that the
+    #       OE meta data version (i.e. ${WORKDIR}/config1.cfg) is listed
+    #       after the in-kernel configuration fragment.
+    # Check if any config fragments are specified.
+    if [ ! -z "${KERNEL_CONFIG_FRAGMENTS}" ]; then
+        for f in ${KERNEL_CONFIG_FRAGMENTS}; do
+            # Check if the config fragment was copied into the WORKDIR from
+            # the OE meta data
+            if [ ! -e "$f" ]; then
+                echo "Could not find kernel config fragment $f"
+                exit 1
+            fi
+        done
+
+        # Now that all the fragments are located merge them.
+        ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
+    fi
+
+    oe_runmake -C ${S} O=${B} olddefconfig
+
+    oe_runmake -C ${S} O=${B} kselftest-merge
+
+    bbplain "Saving defconfig to:\n${B}/defconfig"
+    oe_runmake -C ${B} savedefconfig
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
+    cp -a ${B}/.config ${DEPLOYDIR}/config
+    cp -a ${B}/vmlinux ${DEPLOYDIR}
+    cp ${T}/log.do_compile ${T}/log.do_compile_kernelmodules ${DEPLOYDIR}
+
+    # FIXME 410c fails to build when skales in invoked
+    # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
+    # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
+    # | KeyError: u'ipq8074'
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *sdm845* ) || true
+}
+
+require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-stable_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.4.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.4.y;name=kernel \
+    file://lkft-4.4.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
     file://0001-selftests-create-test-specific-kconfig-fragments.patch \
@@ -70,6 +71,7 @@ COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|
 KERNEL_DEVICETREE_remove_juno = "arm/juno-r2.dtb"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft-4.4.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "

--- a/recipes-kernel/linux/linux-generic-stable_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable_4.9.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=https;branch=linux-4.9.y;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
     file://0001-selftests-lib-add-config-fragment-for-bitmap-printf-.patch \
@@ -24,6 +25,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|dragonboard-410c|hikey|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -60,9 +62,6 @@ do_configure() {
         echo 'CONFIG_IGB=y' >> ${B}/.config
       ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:

--- a/recipes-kernel/linux/linux-hikey-aosp/lkft-4.4.config
+++ b/recipes-kernel/linux/linux-hikey-aosp/lkft-4.4.config
@@ -1,3 +1,7 @@
 # Enable KSM
 # https://bugs.linaro.org/show_bug.cgi?id=3857#c3
 CONFIG_KSM=y
+
+# Autogroup
+# https://bugs.linaro.org/show_bug.cgi?id=3377#c0
+CONFIG_SCHED_AUTOGROUP=y


### PR DESCRIPTION
Three things in three commits:
* add 4.18 stable kernel,
* update all stable kernels to use lkft config fragment, and
* update 4.4 lkft config fragment to include autogroup config.