### PR TITLE
linux-generic: Use nobranch=1 for Git

### DIFF
--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -9,7 +9,7 @@ SRCREV_kernel = "${KERNEL_COMMIT}"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
-    ${KERNEL_REPO};protocol=https;branch=${KERNEL_BRANCH};name=kernel \
+    ${KERNEL_REPO};protocol=https;nobranch=1;name=kernel \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "


### PR DESCRIPTION
Sometimes, only the SRCREV will be provided, and that's fine.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>