### PR TITLE
mali-userland: add the 32-bit driver

### DIFF
--- a/recipes-graphics/mali-userland/mali450-userland_r7p0_01rel0.bb
+++ b/recipes-graphics/mali-userland/mali450-userland_r7p0_01rel0.bb
@@ -1,7 +1,11 @@
 SUMMARY = "ARM Mali Utgard GPU User Space driver for HiKey (drm backend)"
 
+VER ?= "${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '64', 'hf', d)}"
+MALI_TARNAME = "${@bb.utils.contains('VER', '64', 'mali-450_r7p0-01rel0_linux_1arm64.tar.gz', 'mali-450_r7p0-01rel0_linux-armhf_1.tar.gz', d)}"
+MALI_DIRNAME = "${@bb.utils.contains('VER', '64', 'mali-450_r7p0-01rel0_linux_1+arm64', 'mali-450_r7p0-01rel0_linux-armhf_1', d)}"
+
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/mali-450_r7p0-01rel0_linux_1+arm64/END_USER_LICENCE_AGREEMENT.txt;md5=3918cc9836ad038c5a090a0280233eea"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/${MALI_DIRNAME}/END_USER_LICENCE_AGREEMENT.txt;md5=3918cc9836ad038c5a090a0280233eea"
 
 # Disable for non-MALI machines
 python __anonymous() {
@@ -18,18 +22,18 @@ SRC_URI[md5sum] = "118b0307e087345fe7efdf3fe7a69e86"
 SRC_URI[sha256sum] = "34d3b15f0f81487a6b4e3680a79b22afaa2ea221eabe9e559523b48a073afee5"
 SRC_URI[arm64.md5sum] = "118b0307e087345fe7efdf3fe7a69e86"
 SRC_URI[arm64.sha256sum] = "34d3b15f0f81487a6b4e3680a79b22afaa2ea221eabe9e559523b48a073afee5"
+SRC_URI[armhf.md5sum] = "9fd39f6d4a9fa2734dbe1201c54fc421"
+SRC_URI[armhf.sha256sum] = "48c1b3c9225597626af5c0d32f5584a3e2e283e108eb4715b5479e93adf15c2f"
 
 PROVIDES += "virtual/egl virtual/libgles1 virtual/libgles2"
 
 DEPENDS = "libdrm wayland mesa"
 
-VER ?= "${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '64', 'hf', d)}"
-
-SRC_URI = " https://developer.arm.com/-/media/Files/downloads/mali-drivers/user-space/hikey/mali-450_r7p0-01rel0_linux_1arm${VER}.tar.gz;destsuffix=mali;name=arm${VER};downloadfilename=mali-450_r7p0-01rel0_linux_1arm${VER}.tar.gz \
+SRC_URI = " https://developer.arm.com/-/media/Files/downloads/mali-drivers/user-space/hikey/${MALI_TARNAME};name=arm${VER};downloadfilename=${MALI_TARNAME} \
             file://50-mali.rules \
 "
 
-S = "${WORKDIR}/mali-450_r7p0-01rel0_linux_1+arm64/wayland-drm"
+S = "${WORKDIR}/${MALI_DIRNAME}/wayland-drm"
 
 # The driver is a set of binary libraries to install
 # there's nothing to configure or compile


### PR DESCRIPTION
For ease of merging, here is a separate pull request for morty

The armhf variant of driver version r7p0_01rel0 has been recently published
at https://developer.arm.com/products/software/mali-drivers/user-space .

Also drop the destsuffix parameter as it is not supported by HTTP fetcher.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>