### PR TITLE
kselftests: Add iputils-ping to RDEPENDS

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -36,7 +36,7 @@ FILES_kernel-selftests += "${KST_INSTALL_PATH}/bpf/*.o"
 PACKAGES =+ "kernel-selftests-dbg"
 FILES_kernel-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_kernel-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping6 glibc-utils ncurses sudo"
+RDEPENDS_kernel-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping iputils-ping6 glibc-utils ncurses sudo"
 RDEPENDS_kernel-selftests =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_kernel-selftests =+ "util-linux-uuidgen"
 RDEPENDS_kernel-selftests_append_x86 = " cpupower"


### PR DESCRIPTION
While ping is used by net's pmtu.sh test and it's worked
pretty well in the past, the most recent version of test
uses the -M parameter to adjust the PMTU settings, so it
makes sense to use a full-featured ping instead of the one
provided by Busybox.

Details and links can be found here:
  https://bugs.linaro.org/show_bug.cgi?id=3830#c9

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>