### PR TITLE
mali450-userland: Remove libwayland-egl install

### DIFF
--- a/recipes-graphics/mali-userland/mali450-userland_r7p0_01rel0.bb
+++ b/recipes-graphics/mali-userland/mali450-userland_r7p0_01rel0.bb
@@ -55,7 +55,6 @@ do_install() {
     && ln -sf libGLESv2.so.2 libGLESv2.so)
     (cd ${D}/${libdir} && ln -sf libMali.so libgbm.so.1 \
     && ln -sf libgbm.so.1 libgbm.so)
-    (cd ${D}/${libdir} && ln -sf libMali.so libwayland-egl.so)
 
     install -D -m0644 ${WORKDIR}/50-mali.rules \
         ${D}/${base_prefix}/lib/udev/rules.d/50-mali.rules


### PR DESCRIPTION
Since Wayland 1.15.0 provides it's own version of libwayland-egl,

http://git.openembedded.org/openembedded-core/commit/?id=6e5952fcfc13ff4b63c9376bd41a1dbba957f425

As I reviewed there is no way to disable libwayland-egl in wayland
build, this will fix oe-rpb-master build futher testing is needed
in HiKey machine.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>