### PR TITLE
Fixed Hikey960 Kernel to support Hynix UFS

### DIFF
--- a/recipes-kernel/linux/linux-hikey960/ufs.patch
+++ b/recipes-kernel/linux/linux-hikey960/ufs.patch
@@ -1,0 +1,57 @@
+diff --git a/drivers/scsi/ufs/ufs-hi3660.c b/drivers/scsi/ufs/ufs-hi3660.c
+index 9356e828e107..ba32b1ed7848 100644
+--- a/drivers/scsi/ufs/ufs-hi3660.c
++++ b/drivers/scsi/ufs/ufs-hi3660.c
+@@ -25,6 +25,7 @@
+ #include "unipro.h"
+ #include "ufs-hi3660.h"
+ #include "ufshci.h"
++#include "ufs_quirks.h"
+ 
+ static int ufs_hi3660_check_hibern8(struct ufs_hba *hba)
+ {
+@@ -409,6 +410,14 @@ static int ufs_hi3660_get_pwr_dev_param(
+ 
+ static void ufs_hi3660_pwr_change_pre_change(struct ufs_hba *hba)
+ {
++	if (hba->dev_quirks & UFS_DEVICE_QUIRK_HOST_VS_DEBUGSAVECONFIGTIME) {
++		pr_info("ufs flash device must set VS_DebugSaveConfigTime 0x10\n");
++		/* VS_DebugSaveConfigTime */
++		ufshcd_dme_set(hba, UIC_ARG_MIB(0xD0A0), 0x10);
++		/* sync length */
++		ufshcd_dme_set(hba, UIC_ARG_MIB(0x1556), 0x48);
++	}
++
+ 	/* update */
+ 	ufshcd_dme_set(hba, UIC_ARG_MIB(0x15A8), 0x1);
+ 	/* PA_TxSkip */
+diff --git a/drivers/scsi/ufs/ufs_quirks.h b/drivers/scsi/ufs/ufs_quirks.h
+index 71f73d1d1ad1..5d2dfdb41a6f 100644
+--- a/drivers/scsi/ufs/ufs_quirks.h
++++ b/drivers/scsi/ufs/ufs_quirks.h
+@@ -131,4 +131,10 @@ struct ufs_dev_fix {
+  */
+ #define UFS_DEVICE_QUIRK_HOST_PA_SAVECONFIGTIME	(1 << 8)
+ 
++/*
++ * Some UFS devices require VS_DebugSaveConfigTime is 0x10,
++ * enabling this quirk ensure this.
++ */
++#define UFS_DEVICE_QUIRK_HOST_VS_DEBUGSAVECONFIGTIME	(1 << 9)
++
+ #endif /* UFS_QUIRKS_H_ */
+diff --git a/drivers/scsi/ufs/ufshcd.c b/drivers/scsi/ufs/ufshcd.c
+index 794a4600e952..3eadd5fea850 100644
+--- a/drivers/scsi/ufs/ufshcd.c
++++ b/drivers/scsi/ufs/ufshcd.c
+@@ -207,6 +207,8 @@ static struct ufs_dev_fix ufs_fixups[] = {
+ 	UFS_FIX(UFS_VENDOR_SKHYNIX, UFS_ANY_MODEL, UFS_DEVICE_NO_VCCQ),
+ 	UFS_FIX(UFS_VENDOR_SKHYNIX, UFS_ANY_MODEL,
+ 		UFS_DEVICE_QUIRK_HOST_PA_SAVECONFIGTIME),
++	UFS_FIX(UFS_VENDOR_SKHYNIX, UFS_ANY_MODEL,
++		UFS_DEVICE_QUIRK_HOST_VS_DEBUGSAVECONFIGTIME),
+ 
+ 	END_FIX
+ };
+-- 
+2.7.4

--- a/recipes-kernel/linux/linux-hikey960_git.bb
+++ b/recipes-kernel/linux/linux-hikey960_git.bb
@@ -7,6 +7,7 @@ SRCREV_kernel = "939a42450e4d44334f1fbd46428317db5bc813c1"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "git://github.com/96boards-hikey/linux.git;protocol=https;name=kernel;nobranch=1 \
+	   file://ufs.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
I've added the kernel patch to support SK Hynix UFS for Hikey960-4GBRAM-boards. Without this patch the images don't work for the boards with SK Hynix UFS .