### PR TITLE
weston_5%.bbappend: Disable GBM modifiers for hikey.

### DIFF
--- a/recipes-graphics/wayland/weston/0001-configure.ac-disable-GBM-modifiers.patch
+++ b/recipes-graphics/wayland/weston/0001-configure.ac-disable-GBM-modifiers.patch
@@ -1,0 +1,30 @@
+From c5b725e0643cb7a4c12757e4f3a3d6e8ca20ec52 Mon Sep 17 00:00:00 2001
+From: Peter Griffin <peter.griffin@linaro.org>
+Date: Wed, 7 Nov 2018 12:12:41 +0000
+Subject: [PATCH] configure.ac disable GBM modifiers
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+---
+ configure.ac | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 50f8e01..4585e7c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -215,12 +215,6 @@ if test x$enable_drm_compositor = xyes; then
+   PKG_CHECK_MODULES(DRM_COMPOSITOR_FORMATS_BLOB, [libdrm >= 2.4.83],
+ 		    [AC_DEFINE([HAVE_DRM_FORMATS_BLOB], 1, [libdrm supports modifier advertisement])],
+ 		    [AC_MSG_WARN([libdrm does not support modifier advertisement])])
+-  PKG_CHECK_MODULES(DRM_COMPOSITOR_GBM_MODIFIERS, [gbm >= 17.1],
+-		    [AC_DEFINE([HAVE_GBM_MODIFIERS], 1, [GBM supports modifiers])],
+-		    [AC_MSG_WARN([GBM does not support modifiers])])
+-  PKG_CHECK_MODULES(DRM_COMPOSITOR_GBM, [gbm >= 17.2],
+-		    [AC_DEFINE([HAVE_GBM_FD_IMPORT], 1, [gbm supports import with modifiers])],
+-		    [AC_MSG_WARN([GBM does not support dmabuf import, will omit that capability])])
+ fi
+ 
+ 
+-- 
+2.7.4
+

--- a/recipes-graphics/wayland/weston_5%.bbappend
+++ b/recipes-graphics/wayland/weston_5%.bbappend
@@ -2,3 +2,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI_append_poplar = "file://0001-compositor-fbdev.c-Temp-HACK-for-Poplar-and-Weston-w.patch \
 "
+
+SRC_URI_append_hikey = "file://0001-configure.ac-disable-GBM-modifiers.patch \
+"
+
+SRC_URI_append_hikey-32 = "file://0001-configure.ac-disable-GBM-modifiers.patch \
+"


### PR DESCRIPTION
libMali.so (the current r7p0-01rel0 version) doesn't implement
gbm_bo_get_offset().

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>