### PR TITLE
kselftests: Drop iputils-ping6 from RDEPENDS

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -36,7 +36,7 @@ FILES_kernel-selftests += "${KST_INSTALL_PATH}/bpf/*.o"
 PACKAGES =+ "kernel-selftests-dbg"
 FILES_kernel-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_kernel-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping iputils-ping6 glibc-utils ncurses sudo"
+RDEPENDS_kernel-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping glibc-utils ncurses sudo"
 RDEPENDS_kernel-selftests =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_kernel-selftests =+ "util-linux-uuidgen"
 RDEPENDS_kernel-selftests_append_x86 = " cpupower"


### PR DESCRIPTION
As of iputils 20161105, ping6 has been "folded" into ping.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>