### PR TITLE
[LSS-165] edk2-hikey: fix ptable generation

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey960_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey960_git.bb
@@ -37,9 +37,12 @@ do_compile_prepend() {
     # Fix hardcoded value introduced in
     # https://git.linaro.org/uefi/uefi-tools.git/commit/common-functions?id=65e8e8df04f34fc2a87ae9d34f5ef5b6fee5a396
     sed -i -e 's/aarch64-linux-gnu-/${TARGET_PREFIX}/' ${S}/uefi-tools/common-functions
+
+    # Disable fakeroot
+    sed -i -e 's:fakeroot ::g' ${S}/l-loader/generate_ptable.sh
 }
 
-do_compile_append() {
+fakeroot do_compile_append() {
     cd ${EDK2_DIR}/l-loader
     ln -s ${EDK2_DIR}/Build/HiKey960/RELEASE_${AARCH64_TOOLCHAIN}/FV/bl1.bin
     ln -s ${EDK2_DIR}/Build/HiKey960/RELEASE_${AARCH64_TOOLCHAIN}/FV/bl2.bin

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -63,9 +63,12 @@ do_compile_prepend() {
 
     printf "all:\n"  > ${EDK2_DIR}/optee_os/Makefile
     printf "\ttrue" >> ${EDK2_DIR}/optee_os/Makefile
+
+    # Disable fakeroot
+    sed -i -e 's:fakeroot ::g' ${S}/l-loader/generate_ptable.sh
 }
 
-do_compile_append() {
+fakeroot do_compile_append() {
     # Use pre-built aarch32 toolchain
     export PATH=${WORKDIR}/gcc-linaro-6.4.1-2017.08-x86_64_arm-linux-gnueabihf/bin:$PATH
 


### PR DESCRIPTION
Hisilicon is calling 'fakeroot' directly in the ptable script in this specific branch in l-loader, which fails since no 'fakeroot' executable is in $PATH. Remove the hardcoded entries and let OE run it under pseudo.

Before:
[koen@fedora-vm build-rpb]$ hexdump tmp-rpb-glibc/deploy/images/hikey/bootloader/ptable-linux-4g.img
0000000 0000 0000 0000 0000 0000 0000 0000 0000
*
0004400
[koen@fedora-vm build-rpb]$

After:
[koen@fedora-vm meta-96boards]$ hexdump ../../build-rpb/tmp-rpb-glibc/deploy/images/hikey/bootloader/ptable-linux-4g.img | tail -n10
00007d0 0000 0000 0000 0000 0000 0000 0000 0000
*
0000800 3daf 0fc6 8483 4772 798e 693d 47d8 e47d
0000810 e345 fc56 2e8e 49ae f8b2 9d5b 3f26 77e3
0000820 7000 0012 0000 0000 ffde 0071 0000 0000
0000830 0000 0000 0000 0000 0073 0079 0073 0074
0000840 0065 006d 0000 0000 0000 0000 0000 0000
0000850 0000 0000 0000 0000 0000 0000 0000 0000
*
0004400
[koen@fedora-vm meta-96boards]$

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>