### PR TITLE
edk2-hikey: don't touch files from other recipes

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey960_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey960_git.bb
@@ -92,5 +92,4 @@ do_deploy_append() {
 
     # Fix up - move bootloader related files into a subdir
     mv ${DEPLOYDIR}/fip.bin ${DEPLOYDIR}/bootloader/
-    rm -f ${DEPLOY_DIR_IMAGE}/grub-efi-bootaa64.efi
 }

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -128,5 +128,4 @@ do_deploy_append() {
 
     # Fix up - move bootloader related files into a subdir
     mv ${DEPLOYDIR}/fip.bin ${DEPLOYDIR}/bootloader/
-    rm -f ${DEPLOY_DIR_IMAGE}/grub-efi-bootaa64.efi
 }


### PR DESCRIPTION
Doing 'bitbake edk2-hikey ; bitbake edk2-hikey -c deploy -f' will fail because edk2-hikey *deletes* files installed by grub-efi after using them.

Signed-off-by: Koen Kooi <koen.kooi@linaro.org>