### PR TITLE
linux.inc: Fix indentation as per oe-core python style guidelines

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -22,11 +22,11 @@ ALLOW_EMPTY_${KERNEL_PACKAGE_NAME}-devicetree = "1"
 python __anonymous () {
 
     import bb
-    
+
     devicetree = d.getVar('KERNEL_DEVICETREE', True) or ''
     if devicetree:
-    	depends = d.getVar("DEPENDS", True)
-    	d.setVar("DEPENDS", "%s dtc-native" % depends)
+        depends = d.getVar("DEPENDS", True)
+        d.setVar("DEPENDS", "%s dtc-native" % depends)
 }
 
 do_configure_prepend() {


### PR DESCRIPTION
Fixes parse errors e.g.
linux-poplar_git.bb: python should use 4 spaces indentation, but found tabs in linux.inc, line 28

Signed-off-by: Khem Raj <raj.khem@gmail.com>