### PR TITLE
linux: Sync generic 4.9 LSK & RT kernels with other LKFT kernels

### DIFF
--- a/recipes-kernel/linux/linux-generic-lsk_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-lsk_4.9.bb
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.linaro.org/kernel/linux-linaro-stable.git;protocol=https;branch=linux-linaro-lsk-v4.9;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
     file://0001-selftests-lib-add-config-fragment-for-bitmap-printf-.patch \
@@ -16,7 +17,6 @@ SRC_URI = "\
     file://0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch \
     file://0001-selftests-gpio-add-config-fragment-for-gpio-mockup.patch \
     file://0001-selftests-create-cpufreq-kconfig-fragments.patch \
-    file://0001-selftests-sync-add-config-fragment-for-testing-sync-.patch \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
 "
 
@@ -25,6 +25,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|dragonboard-410c|hikey|intel-core2-32|intel-corei7-64|juno"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -34,26 +35,33 @@ DEPENDS += "openssl-native"
 HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
 
 do_configure() {
+    touch ${B}/.scmversion ${S}/.scmversion
+
     # While kernel.bbclass has an architecture mapping, we can't use it because
     # the kernel config file has a different name.
     case "${HOST_ARCH}" in
       aarch64)
         cp ${S}/arch/arm64/configs/lsk_defconfig ${B}/.config
         echo 'CONFIG_STUB_CLK_HI6220=y' >> ${B}/.config
+        # https://bugs.linaro.org/show_bug.cgi?id=3769
+        echo 'CONFIG_ARM64_MODULE_PLTS=y' >> ${B}/.config
       ;;
       arm)
         cp ${S}/arch/arm/configs/lsk_defconfig ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+        # https://bugs.linaro.org/show_bug.cgi?id=3769
+        echo 'CONFIG_ARM_MODULE_PLTS=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
         echo 'CONFIG_IGB=y' >> ${B}/.config
       ;;
+      i686)
+        cp ${S}/arch/x86/configs/i386_defconfig ${B}/.config
+        echo 'CONFIG_IGB=y' >> ${B}/.config
+      ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:

--- a/recipes-kernel/linux/linux-generic-stable-rt_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rt_4.9.bb
@@ -1,7 +1,7 @@
 require linux.inc
 require kselftests.inc
 
-DESCRIPTION = "Generic Linux Stable RT 4.9  kernel"
+DESCRIPTION = "Generic Linux Stable RT 4.9 kernel"
 
 PV = "4.9+git${SRCPV}"
 SRCREV_kernel = "7351926daee6459111f2485fc154ee6cda5615ac"
@@ -9,6 +9,7 @@ SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git;protocol=https;branch=v4.9-rt;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
     file://0001-selftests-lib-add-config-fragment-for-bitmap-printf-.patch \
@@ -16,7 +17,6 @@ SRC_URI = "\
     file://0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch \
     file://0001-selftests-gpio-add-config-fragment-for-gpio-mockup.patch \
     file://0001-selftests-create-cpufreq-kconfig-fragments.patch \
-    file://0001-selftests-sync-add-config-fragment-for-testing-sync-.patch \
     file://0001-selftests-ftrace-add-more-config-fragments.patch \
 "
 
@@ -25,6 +25,7 @@ S = "${WORKDIR}/git"
 COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|dragonboard-410c|hikey|intel-core2-32|intel-corei7-64|juno"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "
@@ -42,11 +43,15 @@ do_configure() {
       aarch64)
         cp ${S}/arch/arm64/configs/defconfig ${B}/.config
         echo 'CONFIG_STUB_CLK_HI6220=y' >> ${B}/.config
+        # https://bugs.linaro.org/show_bug.cgi?id=3769
+        echo 'CONFIG_ARM64_MODULE_PLTS=y' >> ${B}/.config
       ;;
       arm)
         cp ${S}/arch/arm/configs/multi_v7_defconfig ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+        # https://bugs.linaro.org/show_bug.cgi?id=3769
+        echo 'CONFIG_ARM_MODULE_PLTS=y' >> ${B}/.config
       ;;
       x86_64)
         cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
@@ -57,9 +62,6 @@ do_configure() {
         echo 'CONFIG_IGB=y' >> ${B}/.config
       ;;
     esac
-
-    # Make sure to enable NUMA
-    echo 'CONFIG_NUMA=y' >> ${B}/.config
 
     # Check for kernel config fragments. The assumption is that the config
     # fragment will be specified with the absolute path. For example:


### PR DESCRIPTION
A few discrepancies in the 4.9 kernels are now showing as build errors, chiefly because of a patch that has been backported. The patch is therefore dropped from our recipes.