### PR TITLE
Update default tune configuration based on latest OE-Core

### DIFF
--- a/conf/machine/96boards-64.conf
+++ b/conf/machine/96boards-64.conf
@@ -2,7 +2,7 @@
 #@NAME: generic 96boards armv8 machine
 #@DESCRIPTION: generic 96boards armv8 machine
 
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/arm/arch-armv8a.inc
 
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 

--- a/conf/machine/bubblegum.conf
+++ b/conf/machine/bubblegum.conf
@@ -2,7 +2,7 @@
 #@NAME: uCRobotics Bubblegum machine
 #@DESCRIPTION: uCRobotics Bubblegum machine
 
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/tune-cortexa53.inc
 
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 

--- a/conf/machine/hikey.conf
+++ b/conf/machine/hikey.conf
@@ -2,7 +2,7 @@
 #@NAME: LeMaker HiKey machine
 #@DESCRIPTION: LeMaker HiKey machine
 
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/tune-cortexa53.inc
 
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 

--- a/conf/machine/hikey960.conf
+++ b/conf/machine/hikey960.conf
@@ -2,7 +2,7 @@
 #@NAME: HiKey960 machine
 #@DESCRIPTION: HiKey960 development board
 
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/tune-cortexa53.inc
 
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 

--- a/conf/machine/juno.conf
+++ b/conf/machine/juno.conf
@@ -2,7 +2,7 @@
 #@NAME: Juno vexpress
 #@DESCRIPTION: Juno ARM Development Platform
 
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/arm/arch-armv8a.inc
 
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 

--- a/conf/machine/poplar.conf
+++ b/conf/machine/poplar.conf
@@ -2,7 +2,7 @@
 #@NAME: ToCoding Poplar machine
 #@DESCRIPTION: ToCoding Poplar machine
 
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/tune-cortexa53.inc
 
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 


### PR DESCRIPTION
Latest OE-Core removed the arch-armv8 tune file and added a new set of tune files cortex A cores.

@kraj mind having a quick look?