### PR TITLE
linux: Sync generic LSK 4.9 Test defconfigs with other LKFT kernels

### DIFF
--- a/recipes-kernel/linux/linux-generic-lsk-test_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-lsk-test_4.9.bb
@@ -41,13 +41,13 @@ do_configure() {
     # the kernel config file has a different name.
     case "${HOST_ARCH}" in
       aarch64)
-        cp ${S}/arch/arm64/configs/lsk_defconfig ${B}/.config
+        cp ${S}/arch/arm64/configs/defconfig ${B}/.config
         echo 'CONFIG_STUB_CLK_HI6220=y' >> ${B}/.config
         # https://bugs.linaro.org/show_bug.cgi?id=3769
         echo 'CONFIG_ARM64_MODULE_PLTS=y' >> ${B}/.config
       ;;
       arm)
-        cp ${S}/arch/arm/configs/lsk_defconfig ${B}/.config
+        cp ${S}/arch/arm/configs/multi_v7_defconfig ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
         # https://bugs.linaro.org/show_bug.cgi?id=3769


### PR DESCRIPTION
The lsk_defconfig does not exist on the branch
linux-linaro-lsk-v4.9-test of the linux-linaro-stable Git
repository. Use the same defconfigs that other LKFT jobs are
currently using.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>