### PR TITLE
u-boot-juno: Add patch to fix Python build problem

### DIFF
--- a/recipes-bsp/u-boot/files/makefile-honor-python-configuration-properly.patch
+++ b/recipes-bsp/u-boot/files/makefile-honor-python-configuration-properly.patch
@@ -1,0 +1,74 @@
+From 3809e30273e03d762595dbc2a62f3a8398281ec8 Mon Sep 17 00:00:00 2001
+From: =?utf8?q?Cl=C3=A9ment=20B=C5=93sch?= <u@pkh.me>
+Date: Mon, 14 Aug 2017 08:59:11 +0200
+Subject: [PATCH] Makefile: honor PYTHON configuration properly
+
+On some systems `python` is `python3` (for instance, Archlinux). The
+`PYTHON` variable can be used to point to `python2` to have a successful
+build.
+
+The use of `PYTHON` is currently limited in the Makefile and needs to be
+extended in other places:
+
+First, pylibfdt is required to be a Python 2 binding (binman imports
+pylibfdt and is only compatible Python 2), so its setup.py needs to be
+called accordingly. An alternative would be to change the libfdt
+setup.py shebang to python2, but the binding is actually portable. Also,
+it would break on system where there is no such thing as `python2`.
+
+Secondly, the libfdt import checks need to be done against Python 2 as
+well since the Python 2 compiled modules (in this case _libdft.so) can
+not be imported from Python 3.
+
+Note on the libfdt imports: "@if ! PYTHONPATH=tools $(PYTHON) -c 'import
+libfdt'; then..." is probably simpler than the currently sub-optimal
+pipe.
+Reviewed-by: Jonathan Gray <jsg@jsg.id.au>
+---
+ Makefile             | 2 +-
+ scripts/Makefile.spl | 2 +-
+ tools/Makefile       | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 2fc4616..a0f3bfd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1379,7 +1379,7 @@ $(timestamp_h): $(srctree)/Makefile FORCE
+ 	$(call filechk,timestamp.h)
+ 
+ checkbinman: tools
+-	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools python )); then \
++	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools $(PYTHON) )); then \
+ 		echo >&2; \
+ 		echo >&2 '*** binman needs the Python libfdt library.'; \
+ 		echo >&2 '*** Either install it on your system, or try:'; \
+diff --git a/scripts/Makefile.spl b/scripts/Makefile.spl
+index 3ba0007..dd8065d 100644
+--- a/scripts/Makefile.spl
++++ b/scripts/Makefile.spl
+@@ -369,7 +369,7 @@ ifneq ($(cmd_files),)
+ endif
+ 
+ checkdtoc: tools
+-	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools python )); then \
++	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools $(PYTHON) )); then \
+ 		echo '*** dtoc needs the Python libfdt library. Either '; \
+ 		echo '*** install it on your system, or try:'; \
+ 		echo '***'; \
+diff --git a/tools/Makefile b/tools/Makefile
+index a1790eb..086c533 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -138,7 +138,7 @@ tools/_libfdt.so: $(LIBFDT_SRCS) $(LIBFDT_SWIG)
+ 		CPPFLAGS="$(_hostc_flags)" OBJDIR=tools \
+ 		SOURCES="$(LIBFDT_SRCS) tools/libfdt.i" \
+ 		SWIG_OPTS="-I$(srctree)/lib/libfdt -I$(srctree)/lib" \
+-		$(libfdt_tree)/pylibfdt/setup.py --quiet build_ext \
++		$(PYTHON) $(libfdt_tree)/pylibfdt/setup.py build_ext \
+ 			--build-lib tools
+ 
+ ifneq ($(CONFIG_MX23)$(CONFIG_MX28),)
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot-juno.bb
+++ b/recipes-bsp/u-boot/u-boot-juno.bb
@@ -9,6 +9,7 @@ SRCREV = "a624e22f083eb0af7ed868f8bdbcd198c17588ca"
 PV = "v2017.06+2017.07-rc3+git${SRCPV}"
 
 SRC_URI = "git://git.linaro.org/landing-teams/working/arm/u-boot.git;protocol=https;branch=17.10 \
+    file://makefile-honor-python-configuration-properly.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
A problem while building from Sumo onwards was related to
libfdt and using the host's Python. This was not present in
Rocko, probably due to an improved host isolation that was
implemented starting with Sumo.

Quoting Jon Mason, who investigated this issue and proposed
this fix:
  The problem is an overhaul in how libfdt was done in u-boot,
  and this occurred in and after the v2017.07 u-boot release.

  $ git log --oneline  v2017.05..v2017.07 lib/libfdt/
  2bf9412 libfdt: Drop -FDT_ERR_TOODEEP
  727f153 fdt: Stop building the old python libfdt module
  555ba48 fdt: Rename existing python libfdt module
  7e91b10 fdt: Allow swig options to be provided by Makefile
  a2b2caa fdt: Move header files into lib/libfdt
  cf2064d fdt: Add Python bindings

  As you can see above, libfdt requires python.  In sumo, they
  added the "native python" logic to the OE u-boot recipe (to
  correct the fallout from the libfdt changes).  See patch
    https://git.openembedded.org/openembedded-core/commit/?id=71c9fc5a9398dc77a4e0f440a7fde346990c0475

  This is what is causing the problem.  The OE u-boot.inc
  assumes we are running 2018.01 (and is setup to build for
  such), while Juno u-boot is 2017.07-rc3.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>