### PR TITLE
Update Juno's U-boot (and ATF), sync with other branches

### DIFF
--- a/recipes-bsp/atf/atf-juno_git.bb
+++ b/recipes-bsp/atf/atf-juno_git.bb
@@ -5,10 +5,10 @@ DEPENDS += "u-boot-juno zip-native"
 SRCREV = "b762fc7481c66b64eb98b6ff694d569e66253973"
 
 SRC_URI = "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https;name=atf;branch=master \
-    http://releases.linaro.org/members/arm/platforms/17.04/juno-latest-oe-uboot.zip;name=junofip;subdir=juno-oe-uboot \
+    http://releases.linaro.org/members/arm/platforms/18.04/juno-latest-oe-uboot.zip;name=junofip;subdir=juno-oe-uboot \
 "
-SRC_URI[junofip.md5sum] = "12fc772de457930fc60e42bdde97eb0a"
-SRC_URI[junofip.sha256sum] = "be1a3f8b72a0dd98ba1bf9f4fd5415d3adca052c60b090c5dccc178588ec43bc"
+SRC_URI[junofip.md5sum] = "1cf91f8719dbf966b0d7c2b5d6135792"
+SRC_URI[junofip.sha256sum] = "ff01941725f1f67910817a8ec88be9a2db9d132c50b2bb4d13291c471f30b91f"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/u-boot/files/makefile-honor-python-configuration-properly.patch
+++ b/recipes-bsp/u-boot/files/makefile-honor-python-configuration-properly.patch
@@ -1,0 +1,74 @@
+From 3809e30273e03d762595dbc2a62f3a8398281ec8 Mon Sep 17 00:00:00 2001
+From: =?utf8?q?Cl=C3=A9ment=20B=C5=93sch?= <u@pkh.me>
+Date: Mon, 14 Aug 2017 08:59:11 +0200
+Subject: [PATCH] Makefile: honor PYTHON configuration properly
+
+On some systems `python` is `python3` (for instance, Archlinux). The
+`PYTHON` variable can be used to point to `python2` to have a successful
+build.
+
+The use of `PYTHON` is currently limited in the Makefile and needs to be
+extended in other places:
+
+First, pylibfdt is required to be a Python 2 binding (binman imports
+pylibfdt and is only compatible Python 2), so its setup.py needs to be
+called accordingly. An alternative would be to change the libfdt
+setup.py shebang to python2, but the binding is actually portable. Also,
+it would break on system where there is no such thing as `python2`.
+
+Secondly, the libfdt import checks need to be done against Python 2 as
+well since the Python 2 compiled modules (in this case _libdft.so) can
+not be imported from Python 3.
+
+Note on the libfdt imports: "@if ! PYTHONPATH=tools $(PYTHON) -c 'import
+libfdt'; then..." is probably simpler than the currently sub-optimal
+pipe.
+Reviewed-by: Jonathan Gray <jsg@jsg.id.au>
+---
+ Makefile             | 2 +-
+ scripts/Makefile.spl | 2 +-
+ tools/Makefile       | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 2fc4616..a0f3bfd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1379,7 +1379,7 @@ $(timestamp_h): $(srctree)/Makefile FORCE
+ 	$(call filechk,timestamp.h)
+ 
+ checkbinman: tools
+-	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools python )); then \
++	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools $(PYTHON) )); then \
+ 		echo >&2; \
+ 		echo >&2 '*** binman needs the Python libfdt library.'; \
+ 		echo >&2 '*** Either install it on your system, or try:'; \
+diff --git a/scripts/Makefile.spl b/scripts/Makefile.spl
+index 3ba0007..dd8065d 100644
+--- a/scripts/Makefile.spl
++++ b/scripts/Makefile.spl
+@@ -369,7 +369,7 @@ ifneq ($(cmd_files),)
+ endif
+ 
+ checkdtoc: tools
+-	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools python )); then \
++	@if ! ( echo 'import libfdt' | ( PYTHONPATH=tools $(PYTHON) )); then \
+ 		echo '*** dtoc needs the Python libfdt library. Either '; \
+ 		echo '*** install it on your system, or try:'; \
+ 		echo '***'; \
+diff --git a/tools/Makefile b/tools/Makefile
+index a1790eb..086c533 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -138,7 +138,7 @@ tools/_libfdt.so: $(LIBFDT_SRCS) $(LIBFDT_SWIG)
+ 		CPPFLAGS="$(_hostc_flags)" OBJDIR=tools \
+ 		SOURCES="$(LIBFDT_SRCS) tools/libfdt.i" \
+ 		SWIG_OPTS="-I$(srctree)/lib/libfdt -I$(srctree)/lib" \
+-		$(libfdt_tree)/pylibfdt/setup.py --quiet build_ext \
++		$(PYTHON) $(libfdt_tree)/pylibfdt/setup.py build_ext \
+ 			--build-lib tools
+ 
+ ifneq ($(CONFIG_MX23)$(CONFIG_MX28),)
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot-juno.bb
+++ b/recipes-bsp/u-boot/u-boot-juno.bb
@@ -5,11 +5,10 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
 # u-boot needs devtree compiler to parse dts files
 DEPENDS += "dtc-native bc-native"
-SRCREV = "24c6ee8c9d6f0768ced0a564191b0d6676922550"
-PV = "v2017.03+git${SRCPV}"
+SRCREV = "a624e22f083eb0af7ed868f8bdbcd198c17588ca"
+PV = "v2017.06+2017.07-rc3+git${SRCPV}"
 
-SRC_URI = "git://git.linaro.org/landing-teams/working/arm/u-boot.git;protocol=https;branch=17.04 \
-    file://0001-tools-disable-_libfdt.so-swig-present-python-dev-mis.patch \
+SRC_URI = "git://git.linaro.org/landing-teams/working/arm/u-boot.git;protocol=https;branch=17.10 \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/u-boot/u-boot-juno.bb
+++ b/recipes-bsp/u-boot/u-boot-juno.bb
@@ -9,6 +9,7 @@ SRCREV = "a624e22f083eb0af7ed868f8bdbcd198c17588ca"
 PV = "v2017.06+2017.07-rc3+git${SRCPV}"
 
 SRC_URI = "git://git.linaro.org/landing-teams/working/arm/u-boot.git;protocol=https;branch=17.10 \
+    file://makefile-honor-python-configuration-properly.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Rocko, Sumo, Thud and master all share the same configuration for Juno's U-boot (and ATF). It's probably a good idea to make Morty use the same versions of those two packages as the other branches.