### PR TITLE
cpupower: Inherit bash-completion

### DIFF
--- a/recipes-kernel/cpupower/cpupower.bb
+++ b/recipes-kernel/cpupower/cpupower.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425
 DEPENDS = "pciutils gettext-native"
 PROVIDES = "virtual/cpupower"
 
-inherit kernelsrc kernel-arch
+inherit kernelsrc kernel-arch bash-completion
 
 do_populate_lic[depends] += "virtual/kernel:do_patch"
 


### PR DESCRIPTION
Fixes
ERROR: QA Issue: cpupower: Files/directories were installed but not shipped in any package:
  /usr/share/bash-completion
  /usr/share/bash-completion/completions
  /usr/share/bash-completion/completions/cpupower

Signed-off-by: Khem Raj <raj.khem@gmail.com>