### PR TITLE
linux: Remove HiKey 4.4 LTS kernel

### DIFF
--- a/recipes-kernel/linux/linux-hikey-lts-rc
+++ b/recipes-kernel/linux/linux-hikey-lts-rc
@@ -1,1 +1,0 @@
-linux-hikey-aosp

--- a/recipes-kernel/linux/linux-hikey-lts-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-hikey-lts-rc_4.4.bb
@@ -1,1 +1,0 @@
-linux-generic-lts-rc_4.4.bb


### PR DESCRIPTION
The recipe now lives in meta-lkft. Because we want to keep it up to date, using the same kernel config fragments, we need to remove it from here.