### PR TITLE
juno: Build ext4 image for Qemu

### DIFF
--- a/conf/machine/juno.conf
+++ b/conf/machine/juno.conf
@@ -25,6 +25,10 @@ OPTEEOUTPUTMACHINE = "vexpress"
 
 SERIAL_CONSOLE = "115200 ttyAMA0"
 
+# For qemu arm64
+IMAGE_FSTYPES_append = " ext4.gz"
+EXTRA_IMAGECMD_ext4 += " -L rootfs "
+
 # Juno can boot with UEFI or U-Boot
 #EXTRA_IMAGEDEPENDS = "edk2"
 UBOOT_MACHINE = "vexpress_aemv8a_juno_defconfig"


### PR DESCRIPTION
We are now submitting test jobs to Qemu (Arm64) derived from the Juno root file system, but ext4 is not currently being built, which is needed for the Qemu templates. This adds ext4.gz to the `IMAGE_FSTYPES`.