### PR TITLE
burn-boot: Add missing python to rdeps

### DIFF
--- a/recipes-bsp/burn-boot/burn-boot_git.bb
+++ b/recipes-bsp/burn-boot/burn-boot_git.bb
@@ -13,7 +13,7 @@ do_install() {
     install -m 0755 ${S}/hisi-idt.py ${D}${bindir}
 }
 
-RDEPENDS_${PN} += "python-pyserial"
+RDEPENDS_${PN} += "python python-pyserial"
 
 inherit deploy
 


### PR DESCRIPTION
fixes
QA Issue: /usr/bin/hisi-idt.py contained in package burn-boot requires /usr/bin/python, but no providers found in RDEPENDS_burn-boot? [file-rdeps]

Signed-off-by: Khem Raj <raj.khem@gmail.com>