### PR TITLE
layer.conf: Add 96boards-tools->e2fsprogs to SIGGEN_EXCLUDE_SAFE_RECI…

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,13 @@ BBFILE_COLLECTIONS += "meta-96boards"
 BBFILE_PATTERN_meta-96boards := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-96boards = "8"
 LAYERSERIES_COMPAT_meta-96boards = "sumo thud warrior zeus"
+
+SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += "\
+    96boards-tools->e2fsprogs \
+    96boards-tools->util-linux \
+    96boards-tools->gptfdisk \
+    96boards-tools->parted \
+    96boards-tools->udev \
+    96boards-tools->eudev \
+"
+


### PR DESCRIPTION
…PE_DEPS

Fixes
96boards-tools different signature for task do_package_write_ipk.sigdata
hash for dependent task e2fsprogs/e2fsprogs_1.45.4.bb:do_packagedata changed
Hash for dependent task util-linux/util-linux_2.34.bb:do_packagedata changed

Signed-off-by: Khem Raj <raj.khem@gmail.com>