### PR TITLE
layer.conf: Mark systemd as siggen safe for 96boards-tools

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,5 +17,6 @@ SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += "\
     96boards-tools->parted \
     96boards-tools->udev \
     96boards-tools->eudev \
+    96boards-tools->systemd \
 "
 


### PR DESCRIPTION
This helps fix sstate signature changes when using different libc

Hash for dependent task systemd/systemd_244.3.bb:do_packagedata changed from 0cb3d993e0c78f0a1d1c12cfe89f37797198d0de5a80d6367dd36c4730fae278 to 71b91a28dc7c3bfae936b970a3eca5cf2f46e9c27d4d6d9e6d8e66d4b974c3fc
Unable to find matching sigdata for /home/jenkins/oe/world/yoe/sources/openembedded-core/meta/recipes-core/systemd/systemd_244.3.bb:do_packagedata with hashes 0cb3d993e0c78f0a1d1c12cfe89f37797198d0de5a80d6367dd36c4730fae278 or 71b91a28dc7c3bfae936b970a3eca5cf2f46e9c27d4d6d9e6d8e66d4b974c3fc

Signed-off-by: Khem Raj <raj.khem@gmail.com>