### PR TITLE
Install udev rules without execution bits on

### DIFF
--- a/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
+++ b/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
@@ -15,7 +15,7 @@ inherit systemd allarch update-rc.d
 
 do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
-    install -m 0755 ${S}/*.rules ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${S}/*.rules ${D}${sysconfdir}/udev/rules.d/
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${S}/resize-disk ${D}${sysconfdir}/init.d/
 


### PR DESCRIPTION
Avoid this warning: 
localhost systemd-udevd[129]: Configuration file /etc/udev/rules.d/70-96boards-common.rules is marked executable. Please remove executable permission bits. Proceeding anyway.