### PR TITLE
edk2-hikey: Hide warnings for newer GCC's

### DIFF
--- a/recipes-bsp/uefi/edk2-hikey/basetools-ignore-stringop-truncation-gcc-warning.patch
+++ b/recipes-bsp/uefi/edk2-hikey/basetools-ignore-stringop-truncation-gcc-warning.patch
@@ -1,0 +1,32 @@
+From 68bec6047dc6ce4bbe7bbc8f7310e43cba28bf0d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Wed, 9 Dec 2020 11:50:23 -0600
+Subject: [PATCH] basetools: Ignore stringop-truncation gcc warning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ BaseTools/Source/C/Makefiles/header.makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/BaseTools/Source/C/Makefiles/header.makefile b/BaseTools/Source/C/Makefiles/header.makefile
+index 063982b82..fb0fa8a2c 100644
+--- a/BaseTools/Source/C/Makefiles/header.makefile
++++ b/BaseTools/Source/C/Makefiles/header.makefile
+@@ -47,9 +47,9 @@ INCLUDE = $(TOOL_INCLUDE) -I $(MAKEROOT) -I $(MAKEROOT)/Include/Common -I $(MAKE
+ BUILD_CPPFLAGS = $(INCLUDE) -O2
+ ifeq ($(DARWIN),Darwin)
+ # assume clang or clang compatible flags on OS X
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-self-assign -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-stringop-overflow -Wno-self-assign -Wno-unused-result -nostdlib -c -g
+ else
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-stringop-overflow -Wno-unused-result -nostdlib -c -g
+ endif
+ BUILD_LFLAGS =
+ BUILD_CXXFLAGS = -Wno-unused-result
+-- 
+2.25.1
+

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -28,6 +28,7 @@ SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=testing/hik
            git://github.com/96boards-hikey/atf-fastboot.git;name=atffastboot;destsuffix=git/atf-fastboot \
            http://releases.linaro.org/components/toolchain/binaries/6.4-2017.08/arm-linux-gnueabihf/gcc-linaro-6.4.1-2017.08-x86_64_arm-linux-gnueabihf.tar.xz;name=tc \
            file://grub.cfg.in \
+           file://basetools-ignore-stringop-truncation-gcc-warning.patch \
           "
 
 SRC_URI[tc.md5sum] = "8c6084924df023d1e5c0bac2a4ccfa2f"


### PR DESCRIPTION
This is terrible, as the warnings are legit, but this is just taking us back to what we were building previously.

This patch is similar to what was done in OE-Core: https://github.com/openembedded/openembedded-core/commit/278b00ddccb274150ed85e48e984675b40fc9aaa

Here, we add `-Wno-stringop-truncation` (as in OE-Core) but also `-Wno-stringop-overflow`.