### PR TITLE
96boards-tools: Update common-licenses references to match new names

### DIFF
--- a/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
+++ b/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/96boards/96boards-tools"
 SECTION = "devel"
 
 LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 SRCREV = "147e3a97050fdea7c389deb8dfe06314cf82c9ba"
 SRC_URI = "git://github.com/96boards/96boards-tools;branch=master;protocol=https \


### PR DESCRIPTION
The licenses were renamed to match their SPDX names, fix the
references in LIC_FILES_CHKSUM

Signed-off-by: Khem Raj <raj.khem@gmail.com>