### PR TITLE
Global switch to https for github.com

### DIFF
--- a/recipes-bsp/atf/atf-poplar_git.bb
+++ b/recipes-bsp/atf/atf-poplar_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://license.rst;md5=33065335ea03d977d0569f270b39603e"
 DEPENDS += "u-boot-poplar"
 SRCREV = "812fae9e5ee80ddad6bae6bf1c403c9ffaaae984"
 
-SRC_URI = "git://github.com/linaro/poplar-arm-trusted-firmware.git;name=atf;branch=latest"
+SRC_URI = "git://github.com/linaro/poplar-arm-trusted-firmware.git;name=atf;branch=latest;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/l-loader/l-loader-poplar_git.bb
+++ b/recipes-bsp/l-loader/l-loader-poplar_git.bb
@@ -17,7 +17,7 @@ SRCREV = "d7b3ac7748d6607c2dd82cf37326b80a2ede6e5b"
 # l-loader.
 # knowledgeably, it is a hack...
 ###
-SRC_URI = "git://github.com/96boards-poplar/l-loader;branch=latest \
+SRC_URI = "git://github.com/96boards-poplar/l-loader;branch=latest;protocol=https \
            http://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/arm-linux-gnueabihf/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf.tar.xz;name=tc \
 "
 SRC_URI[tc.md5sum] = "01d8860d62807b676762c9c2576dfb22"

--- a/recipes-bsp/u-boot/u-boot-orangepi-i96.bb
+++ b/recipes-bsp/u-boot/u-boot-orangepi-i96.bb
@@ -8,7 +8,7 @@ DEPENDS += "dtc-native bc-native"
 SRCREV = "976c9ecfc85a17ea4681c1eb2d1cf8f12251311b"
 PV = "v2012.04.01+git${SRCPV}"
 
-SRC_URI = "git://github.com/daniel-thompson/u-boot.git;nobranch=1"
+SRC_URI = "git://github.com/daniel-thompson/u-boot.git;protocol=https;nobranch=1"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/uefi/edk2-hikey960_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey960_git.bb
@@ -13,12 +13,12 @@ SRCREV_uefitools = "b37391801290b4adbbc821832470216e98d4e900"
 SRCREV_lloader = "c1cbbf8ab824820b5c1769a1c80dd234c5b57ffc"
 SRCREV_toolsimageshikey960 = "b5ae2c13438eaab429aa584dec7080c181aeee87"
 
-SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=testing/hikey960_v2.5 \
-           git://github.com/ARM-software/arm-trusted-firmware.git;name=atf;branch=master;destsuffix=git/atf \
-           git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=testing/hikey960_v1.3.4;destsuffix=git/OpenPlatformPkg \
+SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=testing/hikey960_v2.5;protocol=https \
+           git://github.com/ARM-software/arm-trusted-firmware.git;name=atf;branch=master;destsuffix=git/atf;protocol=https \
+           git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=testing/hikey960_v1.3.4;destsuffix=git/OpenPlatformPkg;protocol=https \
            git://git.linaro.org/uefi/uefi-tools.git;name=uefitools;destsuffix=git/uefi-tools \
-           git://github.com/96boards-hikey/l-loader.git;name=lloader;branch=testing/hikey960_v1.2;destsuffix=git/l-loader \
-           git://github.com/96boards-hikey/tools-images-hikey960.git;name=toolsimageshikey960;destsuffix=git/tools-images-hikey960 \
+           git://github.com/96boards-hikey/l-loader.git;name=lloader;branch=testing/hikey960_v1.2;destsuffix=git/l-loader;protocol=https \
+           git://github.com/96boards-hikey/tools-images-hikey960.git;name=toolsimageshikey960;destsuffix=git/tools-images-hikey960;protocol=https \
            file://grub.cfg.in \
            file://config \
           "

--- a/recipes-bsp/uefi/edk2-hikey_git.bb
+++ b/recipes-bsp/uefi/edk2-hikey_git.bb
@@ -20,12 +20,12 @@ SRCREV_atffastboot = "af5ddb16266e54745d3b2e354d32b54fefbbbd78"
 # l-loader.
 # knowledgeably, it is a hack...
 ###
-SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=testing/hikey960_v2.5 \
-           git://github.com/ARM-software/arm-trusted-firmware.git;name=atf;branch=master;destsuffix=git/atf \
-           git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=testing/hikey960_v1.3.4;destsuffix=git/OpenPlatformPkg \
+SRC_URI = "git://github.com/96boards-hikey/edk2.git;name=edk2;branch=testing/hikey960_v2.5;protocol=https \
+           git://github.com/ARM-software/arm-trusted-firmware.git;name=atf;branch=master;destsuffix=git/atf;protocol=https \
+           git://github.com/96boards-hikey/OpenPlatformPkg.git;name=openplatformpkg;branch=testing/hikey960_v1.3.4;destsuffix=git/OpenPlatformPkg;protocol=https \
            git://git.linaro.org/uefi/uefi-tools.git;name=uefitools;destsuffix=git/uefi-tools \
-           git://github.com/96boards-hikey/l-loader.git;name=lloader;branch=testing/hikey960_v1.2;destsuffix=git/l-loader \
-           git://github.com/96boards-hikey/atf-fastboot.git;name=atffastboot;destsuffix=git/atf-fastboot \
+           git://github.com/96boards-hikey/l-loader.git;name=lloader;branch=testing/hikey960_v1.2;destsuffix=git/l-loader;protocol=https \
+           git://github.com/96boards-hikey/atf-fastboot.git;name=atffastboot;destsuffix=git/atf-fastboot;protocol=https \
            http://releases.linaro.org/components/toolchain/binaries/6.4-2017.08/arm-linux-gnueabihf/gcc-linaro-6.4.1-2017.08-x86_64_arm-linux-gnueabihf.tar.xz;name=tc \
            file://grub.cfg.in \
           "

--- a/recipes-bsp/uefi/edk2_git.bb
+++ b/recipes-bsp/uefi/edk2_git.bb
@@ -17,8 +17,8 @@ SRCREV_atf = "ed8112606c54d85781fc8429160883d6310ece32"
 SRCREV_openplatformpkg = "b4375302ff2c26786a9d42126359c3a394a65ed4"
 SRCREV_uefitools = "b37391801290b4adbbc821832470216e98d4e900"
 
-SRC_URI = "git://github.com/tianocore/edk2.git;name=edk2 \
-           git://github.com/ARM-software/arm-trusted-firmware.git;name=atf;destsuffix=git/atf \
+SRC_URI = "git://github.com/tianocore/edk2.git;name=edk2;protocol=https \
+           git://github.com/ARM-software/arm-trusted-firmware.git;name=atf;destsuffix=git/atf;protocol=https \
            git://git.linaro.org/uefi/OpenPlatformPkg.git;name=openplatformpkg;destsuffix=git/OpenPlatformPkg \
            git://git.linaro.org/uefi/uefi-tools.git;name=uefitools;destsuffix=git/uefi-tools \
           "

--- a/recipes-connectivity/uim/uim-sysfs_git.bb
+++ b/recipes-connectivity/uim/uim-sysfs_git.bb
@@ -8,7 +8,7 @@ inherit systemd
 PV = "0.0"
 
 SRCREV = "a0236bc252e6484835ce266ae4a50b361f6a902d"
-SRC_URI = "git://github.com/96boards/uim.git"
+SRC_URI = "git://github.com/96boards/uim.git;protocol=https"
 
 S= "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-bubblegum_3.10.bb
+++ b/recipes-kernel/linux/linux-bubblegum_3.10.bb
@@ -6,7 +6,7 @@ PV = "3.10.52+git"
 SRCREV_kernel = "35be6ad831e4966dc5c6c3ff5a718b1aab6bb81b"
 SRCREV_FORMAT = "kernel"
 
-SRC_URI = "git://github.com/96boards-bubblegum/linux.git;protocol=https;branch=bubblegum96-3.10;name=kernel \
+SRC_URI = "git://github.com/96boards-bubblegum/linux.git;protocol=https;branch=bubblegum96-3.10;name=kernel;protocol=https \
            file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \
            file://0002-arm64-kill-off-the-libgcc-dependency.patch \
            file://0003-option-serial-remove-duplicate-define.patch \


### PR DESCRIPTION
Fixes "uses git protocol which is no longer supported by
github. Please change to ;protocol=https in the url."

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>