### PR TITLE
CI: don't use qcom branch in premerge.yml

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -9,5 +9,5 @@ jobs:
     with:
       local_repo: ${{github.repository}}
       local_ref: refs/pull/${{github.event.pull_request.number}}/head
-      branch: qcom/${{github.base_ref}}
+      branch: ${{github.base_ref}}
     secrets: inherit


### PR DESCRIPTION
The qcom/master branch of oe-rpb-manifest has dropped meta-96boards. Use non-qcom branches for CI.